### PR TITLE
Add import-safe MLX backend skeleton

### DIFF
--- a/docs/impl/0001-import-safe-backend-skeleton.md
+++ b/docs/impl/0001-import-safe-backend-skeleton.md
@@ -1,0 +1,53 @@
+# 0001 - Import-Safe Backend Skeleton
+
+## Issue Goal
+
+Create the smallest MLX backend namespace needed for future work while keeping
+all existing PyTorch/CUDA behavior untouched. Phase 0 is a skeleton only: it must
+be importable without loading heavyweight runtime packages or existing eager
+CUDA-oriented modules.
+
+## Files Created
+
+- `src/reap/backends/__init__.py` - import-light namespace for optional backend
+  implementations.
+- `src/reap/backends/mlx/__init__.py` - import-light MLX backend namespace with
+  metadata only.
+- `tests/test_mlx_no_torch_import.py` - subprocess import-safety regression
+  test.
+- `docs/impl/0001-import-safe-backend-skeleton.md` - implementation notes and
+  contract for this phase.
+
+## Import-Safety Contract
+
+- `import reap.backends` and `import reap.backends.mlx` must succeed with only
+  `PYTHONPATH=src`.
+- Backend namespace imports must not import `torch`, `vllm`, `mlx`, `mlx_lm`, or
+  existing eager CUDA/PyTorch implementation modules.
+- Optional runtime dependencies belong in future concrete implementation modules
+  or inside explicit functions, not package `__init__` files.
+- Phase 0 does not expose router, observer, pruning, evaluation, or CLI APIs.
+
+## Test Strategy
+
+`tests/test_mlx_no_torch_import.py` launches a fresh Python subprocess with
+`PYTHONPATH` set to `src`. Inside that subprocess it installs a temporary
+`sys.meta_path` import blocker for the root packages `torch`, `vllm`, `mlx`, and
+`mlx_lm`, imports `reap.backends.mlx`, and then checks `sys.modules` to ensure no
+blocked package or submodule was loaded. It also asserts that known eager REAP
+modules such as `reap.data`, `reap.eval`, `reap.main`, and `reap.prune` were not
+loaded indirectly. Running in a subprocess avoids pytest plugins or the parent
+test process polluting the import state.
+
+## Safe Commands
+
+- `PYTHONPATH=src pytest -q tests/test_mlx_no_torch_import.py`
+- `git diff --check`
+- `PYTHONPATH=src python3 -c "import reap.backends.mlx"`
+
+## Deferred Work
+
+- Backend registry or routing selection.
+- MLX model adapters and mlx-lm integration.
+- Router observation, pruning, merging, evaluation, and CLI support.
+- Any changes to existing PyTorch/CUDA modules.

--- a/src/reap/backends/__init__.py
+++ b/src/reap/backends/__init__.py
@@ -1,0 +1,8 @@
+"""Backend namespace for optional REAP runtimes.
+
+This package is intentionally import-light. Backend implementations should keep
+heavy or optional runtime imports inside explicit implementation modules or
+functions, not at namespace import time.
+"""
+
+__all__: tuple[str, ...] = ()

--- a/src/reap/backends/mlx/__init__.py
+++ b/src/reap/backends/mlx/__init__.py
@@ -1,0 +1,9 @@
+"""MLX backend namespace skeleton.
+
+Phase 0 exposes no runtime functionality. Importing this module must remain
+safe on machines without Torch, vLLM, MLX, or mlx-lm installed.
+"""
+
+BACKEND_NAME = "mlx"
+
+__all__: tuple[str, ...] = ("BACKEND_NAME",)

--- a/tests/test_mlx_no_torch_import.py
+++ b/tests/test_mlx_no_torch_import.py
@@ -1,0 +1,82 @@
+"""Import-safety tests for the MLX backend namespace."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_importing_mlx_backend_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm")
+        EAGER_REAP_MODULES = (
+            "reap.data",
+            "reap.eval",
+            "reap.layerwise_observer",
+            "reap.layerwise_prune",
+            "reap.main",
+            "reap.model_util",
+            "reap.models",
+            "reap.observer",
+            "reap.prune",
+        )
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX backend import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        import reap.backends.mlx
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX backend import: "
+                + ", ".join(forbidden_loaded)
+            )
+
+        eager_reap_loaded = sorted(
+            name for name in sys.modules if name in EAGER_REAP_MODULES
+        )
+        if eager_reap_loaded:
+            raise AssertionError(
+                "eager REAP modules loaded during MLX backend import: "
+                + ", ".join(eager_reap_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary
- add import-light backend namespace under `src/reap/backends/`
- add MLX backend skeleton metadata only
- add subprocess regression test proving the skeleton import does not load torch/vLLM/MLX runtimes or eager REAP CUDA modules
- document Phase 0 implementation notes in `docs/impl/0001-import-safe-backend-skeleton.md`

Closes #1.

## Tests
- `PYTHONPATH=src pytest -q tests/test_mlx_no_torch_import.py`
- `git diff --check`