### PR TITLE
Add MLX Qwen3 router adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ wheels/
 *.egg-info
 
 # Virtual environments
-.venv
+.venv/
 
 # reap specfic
 artifacts/

--- a/src/reap/backends/mlx/router.py
+++ b/src/reap/backends/mlx/router.py
@@ -1,0 +1,135 @@
+"""Router adapters for MLX-backed MoE models.
+
+This module is intentionally import-light: importing it must not require MLX,
+MLX-LM, Torch, vLLM, or the existing eager CUDA/PyTorch REAP modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class RouterResult:
+    """Architecture-neutral selected-router output."""
+
+    indices: Any
+    scores: Any
+    logits: Any | None = None
+    score_mode: str = "actual"
+
+
+def _require_mlx_core():
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "Qwen3MoeRouter requires the optional 'mlx' package to execute. "
+            "Install MLX in the active environment before routing."
+        ) from exc
+    return mx
+
+
+def _config_value(
+    config: Mapping[str, Any] | None,
+    *keys: str,
+    default: Any = None,
+) -> Any:
+    if config is None:
+        return default
+    for key in keys:
+        value = config.get(key)
+        if value is not None:
+            return value
+    return default
+
+
+def _live_or_config_value(
+    module: Any,
+    live_attr: str,
+    config: Mapping[str, Any] | None,
+    *config_keys: str,
+    default: Any = None,
+) -> Any:
+    value = getattr(module, live_attr, None)
+    if value is not None:
+        return value
+    return _config_value(config, *config_keys, default=default)
+
+
+class Qwen3MoeRouter:
+    """Qwen3-MoE router adapter matching MLX-LM routing semantics."""
+
+    def __init__(
+        self,
+        mlp_layer: Any,
+        config: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.gate = getattr(mlp_layer, "gate", None)
+        if self.gate is None:
+            raise ValueError("Qwen3MoeRouter requires an MLX MoE layer with a gate.")
+
+        self.top_k = _live_or_config_value(
+            mlp_layer,
+            "top_k",
+            config,
+            "num_experts_per_tok",
+            "top_k",
+        )
+        if self.top_k is None:
+            raise ValueError(
+                "Qwen3MoeRouter requires top-k from mlp_layer.top_k, "
+                "config['num_experts_per_tok'], or config['top_k']."
+            )
+        self.top_k = int(self.top_k)
+        if self.top_k < 1:
+            raise ValueError(f"top_k must be positive, got {self.top_k}.")
+
+        self.norm_topk_prob = bool(
+            _live_or_config_value(
+                mlp_layer,
+                "norm_topk_prob",
+                config,
+                "norm_topk_prob",
+                default=False,
+            )
+        )
+
+    def __call__(self, hidden_states: Any) -> RouterResult:
+        mx = _require_mlx_core()
+
+        if hidden_states.ndim not in (2, 3):
+            raise ValueError(
+                "Qwen3MoeRouter expects hidden states with shape "
+                "[tokens, hidden] or [batch, seq, hidden], got "
+                f"{hidden_states.shape}."
+            )
+
+        leading_shape = hidden_states.shape[:-1]
+        hidden_size = hidden_states.shape[-1]
+        flat_hidden_states = hidden_states.reshape(-1, hidden_size)
+
+        logits = self.gate(flat_hidden_states)
+        num_experts = logits.shape[-1]
+        if self.top_k > num_experts:
+            raise ValueError(
+                f"top_k={self.top_k} cannot exceed num_experts={num_experts}."
+            )
+
+        gates = mx.softmax(logits, axis=-1, precise=True)
+        flat_indices = mx.argpartition(gates, kth=-self.top_k, axis=-1)[
+            ..., -self.top_k :
+        ]
+        flat_scores = mx.take_along_axis(gates, flat_indices, axis=-1)
+
+        if self.norm_topk_prob:
+            flat_scores = flat_scores / flat_scores.sum(axis=-1, keepdims=True)
+
+        output_shape = (*leading_shape, self.top_k)
+        return RouterResult(
+            indices=flat_indices.reshape(output_shape),
+            scores=flat_scores.reshape(output_shape),
+            logits=None,
+            score_mode="actual",
+        )

--- a/tests/test_mlx_router.py
+++ b/tests/test_mlx_router.py
@@ -1,0 +1,298 @@
+"""Tests for MLX router adapters."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from reap.backends.mlx.router import Qwen3MoeRouter, RouterResult
+
+
+MLX_AVAILABLE = importlib.util.find_spec("mlx") is not None
+
+
+def test_router_contracts_import_without_mlx():
+    result = RouterResult(indices="indices", scores="scores")
+
+    assert result.indices == "indices"
+    assert result.scores == "scores"
+    assert result.logits is None
+    assert result.score_mode == "actual"
+    assert Qwen3MoeRouter is not None
+
+
+def test_router_module_import_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX router import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        from reap.backends.mlx.router import Qwen3MoeRouter, RouterResult
+
+        assert Qwen3MoeRouter is not None
+        assert RouterResult(indices=1, scores=2).score_mode == "actual"
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX router import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+requires_mlx = pytest.mark.skipif(
+    not MLX_AVAILABLE,
+    reason="MLX is not installed in this environment.",
+)
+
+
+class TinyGate:
+    def __init__(self, mx, weight, bias=None):
+        self.weight = mx.array(weight)
+        self.bias = None if bias is None else mx.array(bias)
+
+    def __call__(self, hidden_states):
+        logits = hidden_states @ self.weight
+        if self.bias is not None:
+            logits = logits + self.bias
+        return logits
+
+
+class TinyMlp:
+    def __init__(
+        self,
+        mx,
+        *,
+        top_k=None,
+        norm_topk_prob=None,
+    ):
+        self.gate = TinyGate(
+            mx,
+            weight=[
+                [1.0, -0.5, 0.25, 0.0],
+                [0.0, 0.75, -0.25, 0.5],
+                [-0.5, 0.0, 0.5, 1.0],
+            ],
+            bias=[0.0, 0.1, -0.2, 0.3],
+        )
+        if top_k is not None:
+            self.top_k = top_k
+        if norm_topk_prob is not None:
+            self.norm_topk_prob = norm_topk_prob
+
+
+def qwen_reference(mx, mlp, hidden_states, top_k, norm_topk_prob):
+    leading_shape = hidden_states.shape[:-1]
+    flat_hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+
+    logits = mlp.gate(flat_hidden_states)
+    gates = mx.softmax(logits, axis=-1, precise=True)
+    indices = mx.argpartition(gates, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(gates, indices, axis=-1)
+
+    if norm_topk_prob:
+        scores = scores / scores.sum(axis=-1, keepdims=True)
+
+    output_shape = (*leading_shape, top_k)
+    return indices.reshape(output_shape), scores.reshape(output_shape)
+
+
+def assert_same_indices(actual, expected):
+    assert actual.tolist() == expected.tolist()
+
+
+def assert_allclose(mx, actual, expected, *, atol=1e-6):
+    diff = mx.max(mx.abs(actual - expected))
+    mx.eval(diff)
+    assert float(diff) <= atol
+
+
+@requires_mlx
+def test_qwen_router_accepts_2d_hidden_states():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx, top_k=2, norm_topk_prob=False)
+    hidden_states = mx.array(
+        [
+            [0.2, 0.4, 0.6],
+            [1.0, -0.5, 0.25],
+            [-0.25, 0.5, 1.25],
+        ]
+    )
+
+    result = Qwen3MoeRouter(mlp, {"num_experts_per_tok": 1})(hidden_states)
+    expected_indices, expected_scores = qwen_reference(
+        mx,
+        mlp,
+        hidden_states,
+        top_k=2,
+        norm_topk_prob=False,
+    )
+
+    assert result.indices.shape == (3, 2)
+    assert result.scores.shape == (3, 2)
+    assert result.logits is None
+    assert result.score_mode == "actual"
+    assert_same_indices(result.indices, expected_indices)
+    assert_allclose(mx, result.scores, expected_scores)
+
+
+@requires_mlx
+def test_qwen_router_accepts_3d_hidden_states():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx)
+    hidden_states = mx.array(
+        [
+            [[0.2, 0.4, 0.6], [1.0, -0.5, 0.25]],
+            [[-0.25, 0.5, 1.25], [0.0, 1.0, -1.0]],
+        ]
+    )
+
+    result = Qwen3MoeRouter(
+        mlp,
+        {"num_experts_per_tok": 3, "norm_topk_prob": False},
+    )(hidden_states)
+    expected_indices, expected_scores = qwen_reference(
+        mx,
+        mlp,
+        hidden_states,
+        top_k=3,
+        norm_topk_prob=False,
+    )
+
+    assert result.indices.shape == (2, 2, 3)
+    assert result.scores.shape == (2, 2, 3)
+    assert_same_indices(result.indices, expected_indices)
+    assert_allclose(mx, result.scores, expected_scores)
+
+
+@requires_mlx
+def test_qwen_router_returns_valid_expert_indices():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx, top_k=2)
+    hidden_states = mx.array([[0.5, 0.25, -0.75], [1.0, 1.0, 1.0]])
+
+    result = Qwen3MoeRouter(mlp)(hidden_states)
+
+    min_index = mx.min(result.indices)
+    max_index = mx.max(result.indices)
+    mx.eval(min_index, max_index)
+
+    assert int(min_index) >= 0
+    assert int(max_index) < 4
+
+
+@requires_mlx
+def test_qwen_router_renormalizes_selected_scores_when_enabled():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx, top_k=2, norm_topk_prob=True)
+    hidden_states = mx.array([[0.5, 0.25, -0.75], [1.0, 1.0, 1.0]])
+
+    result = Qwen3MoeRouter(mlp)(hidden_states)
+    selected_score_sums = result.scores.sum(axis=-1)
+
+    assert_allclose(mx, selected_score_sums, mx.ones(selected_score_sums.shape))
+
+
+@requires_mlx
+def test_qwen_router_keeps_full_softmax_scores_when_not_renormalized():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx, top_k=2, norm_topk_prob=False)
+    hidden_states = mx.array([[0.5, 0.25, -0.75], [1.0, 1.0, 1.0]])
+
+    result = Qwen3MoeRouter(mlp)(hidden_states)
+    expected_indices, expected_scores = qwen_reference(
+        mx,
+        mlp,
+        hidden_states,
+        top_k=2,
+        norm_topk_prob=False,
+    )
+
+    assert_same_indices(result.indices, expected_indices)
+    assert_allclose(mx, result.scores, expected_scores)
+    max_score_sum = mx.max(result.scores.sum(axis=-1))
+    mx.eval(max_score_sum)
+    assert float(max_score_sum) < 1.0
+
+
+@requires_mlx
+def test_qwen_router_supports_single_token_and_top_k_one():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx, top_k=1, norm_topk_prob=True)
+    hidden_states = mx.array([[0.5, 0.25, -0.75]])
+
+    result = Qwen3MoeRouter(mlp)(hidden_states)
+    expected_indices, expected_scores = qwen_reference(
+        mx,
+        mlp,
+        hidden_states,
+        top_k=1,
+        norm_topk_prob=True,
+    )
+
+    assert result.indices.shape == (1, 1)
+    assert result.scores.shape == (1, 1)
+    assert_same_indices(result.indices, expected_indices)
+    assert_allclose(mx, result.scores, expected_scores)
+    assert_allclose(mx, result.scores.sum(axis=-1), mx.ones((1,)))
+
+
+@requires_mlx
+def test_qwen_router_prefers_live_top_k_over_config():
+    import mlx.core as mx
+
+    mlp = TinyMlp(mx, top_k=1, norm_topk_prob=False)
+    hidden_states = mx.array([[0.5, 0.25, -0.75]])
+
+    result = Qwen3MoeRouter(mlp, {"num_experts_per_tok": 3})(hidden_states)
+
+    assert result.indices.shape == (1, 1)


### PR DESCRIPTION
## Summary

- Add an import-light MLX router module with RouterResult and Qwen3MoeRouter.
- Match Qwen3 MLX-LM routing semantics with full softmax, argpartition, selected-score gather, and optional selected-score renormalization.
- Add synthetic router tests plus a subprocess import-safety regression for the router module.
- Normalize the local development venv ignore entry to .venv/.

Closes #2

## Validation

- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py
- git diff --check