### PR TITLE
Add MLX pruning accumulator

### DIFF
--- a/src/reap/backends/mlx/metrics.py
+++ b/src/reap/backends/mlx/metrics.py
@@ -1,0 +1,250 @@
+"""NumPy pruning accumulators for MLX-backed MoE observation.
+
+This module is intentionally independent from the existing Torch pruning
+metrics. MLX observer code should pass compact selected-route arrays here after
+forcing any needed MLX evaluation boundaries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+_FLOAT_EPS = np.finfo(np.float64).eps
+
+
+@dataclass
+class PruningState:
+    """Pruning-only observer state for one MoE layer."""
+
+    num_experts: int
+    total_tokens: int
+    expert_frequency: np.ndarray
+    pairwise_expert_frequency: np.ndarray
+    ean_sum: np.ndarray
+    weighted_ean_sum: np.ndarray
+    weighted_expert_frequency_sum: np.ndarray
+    max_activations: np.ndarray
+
+    @classmethod
+    def initialize(cls, num_experts: int) -> "PruningState":
+        """Create zero-initialized pruning state for ``num_experts`` experts."""
+        num_experts = int(num_experts)
+        if num_experts < 1:
+            raise ValueError(f"num_experts must be positive, got {num_experts}.")
+
+        return cls(
+            num_experts=num_experts,
+            total_tokens=0,
+            expert_frequency=np.zeros(num_experts, dtype=np.int64),
+            pairwise_expert_frequency=np.zeros(
+                (num_experts, num_experts),
+                dtype=np.int64,
+            ),
+            ean_sum=np.zeros(num_experts, dtype=np.float64),
+            weighted_ean_sum=np.zeros(num_experts, dtype=np.float64),
+            weighted_expert_frequency_sum=np.zeros(num_experts, dtype=np.float64),
+            max_activations=np.zeros(num_experts, dtype=np.float32),
+        )
+
+    def accumulate(
+        self,
+        routing: Any | None = None,
+        *,
+        indices: Any | None = None,
+        scores: Any | None = None,
+        selected_outputs: Any | None = None,
+        selected_output_norms: Any | None = None,
+        selected_output_maxes: Any | None = None,
+    ) -> "PruningState":
+        """Accumulate one selected-route batch into this state.
+
+        ``indices`` and ``scores`` must share shape ``[..., top_k]``. Pass either
+        selected expert outputs shaped ``[..., top_k, hidden]`` or precomputed
+        norms and maxes shaped like ``indices``.
+        """
+        if routing is not None:
+            if indices is not None or scores is not None:
+                raise ValueError(
+                    "Pass either routing or explicit indices/scores, not both."
+                )
+            indices = getattr(routing, "indices", None)
+            scores = getattr(routing, "scores", None)
+
+        if indices is None or scores is None:
+            raise ValueError("accumulate requires selected expert indices and scores.")
+
+        indices_array = np.asarray(indices, dtype=np.int64)
+        scores_array = np.asarray(scores, dtype=np.float64)
+        self._validate_route_arrays(indices_array, scores_array)
+
+        if indices_array.shape[-1] == 0:
+            raise ValueError("indices must include at least one selected expert.")
+
+        token_count = int(np.prod(indices_array.shape[:-1]))
+        if token_count == 0:
+            return self
+
+        flat_indices = indices_array.reshape(-1)
+        min_index = int(flat_indices.min())
+        max_index = int(flat_indices.max())
+        if min_index < 0 or max_index >= self.num_experts:
+            raise ValueError(
+                "selected expert indices must be in [0, num_experts): "
+                f"got min={min_index}, max={max_index}, "
+                f"num_experts={self.num_experts}."
+            )
+
+        norms_array = self._selected_output_norms(
+            indices_array,
+            selected_outputs=selected_outputs,
+            selected_output_norms=selected_output_norms,
+        )
+        maxes_array = self._selected_output_maxes(
+            indices_array,
+            selected_outputs=selected_outputs,
+            selected_output_maxes=selected_output_maxes,
+        )
+
+        batch_frequency = np.bincount(
+            flat_indices,
+            minlength=self.num_experts,
+        )[: self.num_experts].astype(np.int64, copy=False)
+
+        self.total_tokens += token_count
+        self.expert_frequency += batch_frequency
+        self.pairwise_expert_frequency += (
+            batch_frequency[:, None] + batch_frequency[None, :]
+        )
+
+        flat_norms = norms_array.reshape(-1).astype(np.float64, copy=False)
+        flat_scores = scores_array.reshape(-1)
+        flat_maxes = maxes_array.reshape(-1).astype(np.float32, copy=False)
+
+        np.add.at(self.ean_sum, flat_indices, flat_norms)
+        np.add.at(self.weighted_ean_sum, flat_indices, flat_norms * flat_scores)
+        np.add.at(self.weighted_expert_frequency_sum, flat_indices, flat_scores)
+        np.maximum.at(self.max_activations, flat_indices, flat_maxes)
+
+        return self
+
+    def report(self) -> dict[str, Any]:
+        """Return pruning data compatible with the existing observer schema."""
+        token_denominator = max(self.total_tokens, 1)
+        count_denominator = np.maximum(
+            self.expert_frequency.astype(np.float64),
+            _FLOAT_EPS,
+        )
+
+        return {
+            "total_tokens": int(self.total_tokens),
+            "expert_frequency": self.expert_frequency.copy(),
+            "pairwise_expert_frequency": self.pairwise_expert_frequency.copy(),
+            "expert_proba": self.expert_frequency.astype(np.float64)
+            / token_denominator,
+            "ean_sum": self.ean_sum.copy(),
+            "ean_mean": (self.ean_sum / count_denominator).astype(np.float32),
+            "weighted_ean_sum": self.weighted_ean_sum.copy(),
+            "weighted_expert_frequency_sum": (
+                self.weighted_expert_frequency_sum.copy()
+            ),
+            "reap": (self.weighted_ean_sum / count_denominator).astype(np.float32),
+            "max_activations": self.max_activations.copy(),
+        }
+
+    def _validate_route_arrays(
+        self,
+        indices_array: np.ndarray,
+        scores_array: np.ndarray,
+    ) -> None:
+        if indices_array.ndim < 1:
+            raise ValueError(
+                "indices must have shape [..., top_k], got a scalar value."
+            )
+        if indices_array.shape != scores_array.shape:
+            raise ValueError(
+                "indices and scores must have the same shape: "
+                f"{indices_array.shape} != {scores_array.shape}."
+            )
+
+    def _selected_output_norms(
+        self,
+        indices_array: np.ndarray,
+        *,
+        selected_outputs: Any | None,
+        selected_output_norms: Any | None,
+    ) -> np.ndarray:
+        if selected_output_norms is not None:
+            norms_array = np.asarray(selected_output_norms, dtype=np.float64)
+            self._validate_selected_stat_shape(
+                "selected_output_norms",
+                norms_array,
+                indices_array.shape,
+            )
+            return norms_array
+
+        if selected_outputs is None:
+            raise ValueError(
+                "selected_outputs or selected_output_norms must be provided "
+                "for non-empty accumulation."
+            )
+
+        outputs_array = np.asarray(selected_outputs)
+        self._validate_selected_output_shape(outputs_array, indices_array.shape)
+        return np.linalg.norm(outputs_array, axis=-1).astype(np.float64, copy=False)
+
+    def _selected_output_maxes(
+        self,
+        indices_array: np.ndarray,
+        *,
+        selected_outputs: Any | None,
+        selected_output_maxes: Any | None,
+    ) -> np.ndarray:
+        if selected_output_maxes is not None:
+            maxes_array = np.asarray(selected_output_maxes, dtype=np.float32)
+            self._validate_selected_stat_shape(
+                "selected_output_maxes",
+                maxes_array,
+                indices_array.shape,
+            )
+            return maxes_array
+
+        if selected_outputs is None:
+            raise ValueError(
+                "selected_outputs or selected_output_maxes must be provided "
+                "for non-empty accumulation."
+            )
+
+        outputs_array = np.asarray(selected_outputs)
+        self._validate_selected_output_shape(outputs_array, indices_array.shape)
+        return np.max(outputs_array, axis=-1).astype(np.float32, copy=False)
+
+    def _validate_selected_stat_shape(
+        self,
+        name: str,
+        values: np.ndarray,
+        expected_shape: tuple[int, ...],
+    ) -> None:
+        if values.shape != expected_shape:
+            raise ValueError(
+                f"{name} must have shape {expected_shape}, got {values.shape}."
+            )
+
+    def _validate_selected_output_shape(
+        self,
+        values: np.ndarray,
+        route_shape: tuple[int, ...],
+    ) -> None:
+        if values.shape[:-1] != route_shape:
+            raise ValueError(
+                "selected_outputs must have shape [..., top_k, hidden] matching "
+                f"indices shape {route_shape}, got {values.shape}."
+            )
+        if values.shape[-1] == 0:
+            raise ValueError("selected_outputs hidden dimension must be non-empty.")
+
+
+__all__ = ["PruningState"]

--- a/tests/test_mlx_metrics.py
+++ b/tests/test_mlx_metrics.py
@@ -1,0 +1,287 @@
+"""Tests for MLX pruning metric accumulation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from reap.backends.mlx.metrics import PruningState
+from reap.backends.mlx.router import RouterResult
+
+
+def test_pruning_state_initialize_shapes_and_dtypes():
+    state = PruningState.initialize(3)
+
+    assert state.num_experts == 3
+    assert state.total_tokens == 0
+    assert state.expert_frequency.shape == (3,)
+    assert state.expert_frequency.dtype == np.int64
+    assert state.pairwise_expert_frequency.shape == (3, 3)
+    assert state.pairwise_expert_frequency.dtype == np.int64
+    assert state.ean_sum.dtype == np.float64
+    assert state.weighted_ean_sum.dtype == np.float64
+    assert state.weighted_expert_frequency_sum.dtype == np.float64
+    assert state.max_activations.dtype == np.float32
+
+    report = state.report()
+    assert report["total_tokens"] == 0
+    np.testing.assert_array_equal(report["expert_frequency"], np.zeros(3))
+    np.testing.assert_array_equal(
+        report["pairwise_expert_frequency"],
+        np.zeros((3, 3)),
+    )
+    np.testing.assert_allclose(report["expert_proba"], np.zeros(3))
+    np.testing.assert_allclose(report["ean_mean"], np.zeros(3))
+    np.testing.assert_allclose(report["reap"], np.zeros(3))
+
+
+def test_metrics_module_import_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX metrics import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        from reap.backends.mlx.metrics import PruningState
+
+        assert PruningState.initialize(2).report()["total_tokens"] == 0
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX metrics import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_accumulate_from_selected_outputs_topk_one():
+    state = PruningState.initialize(2)
+
+    indices = np.array([[0], [1], [0]], dtype=np.int64)
+    scores = np.array([[0.8], [0.5], [0.2]], dtype=np.float32)
+    selected_outputs = np.array(
+        [
+            [[3.0, 4.0]],
+            [[0.0, 6.0]],
+            [[5.0, 12.0]],
+        ],
+        dtype=np.float32,
+    )
+
+    state.accumulate(
+        indices=indices,
+        scores=scores,
+        selected_outputs=selected_outputs,
+    )
+
+    report = state.report()
+    assert report["total_tokens"] == 3
+    np.testing.assert_array_equal(report["expert_frequency"], [2, 1])
+    np.testing.assert_array_equal(
+        report["pairwise_expert_frequency"],
+        [[4, 3], [3, 2]],
+    )
+    np.testing.assert_allclose(report["expert_proba"], [2 / 3, 1 / 3])
+    np.testing.assert_allclose(report["ean_sum"], [18.0, 6.0])
+    np.testing.assert_allclose(report["ean_mean"], [9.0, 6.0])
+    np.testing.assert_allclose(report["weighted_ean_sum"], [6.6, 3.0])
+    np.testing.assert_allclose(
+        report["weighted_expert_frequency_sum"],
+        [1.0, 0.5],
+    )
+    np.testing.assert_allclose(report["reap"], [3.3, 3.0])
+    np.testing.assert_allclose(report["max_activations"], [12.0, 6.0])
+
+
+def test_accumulate_from_precomputed_stats_topk_greater_than_one():
+    state = PruningState.initialize(3)
+
+    indices = np.array([[0, 2], [1, 0], [2, 1]], dtype=np.int64)
+    scores = np.array([[0.7, 0.3], [0.9, 0.4], [0.6, 0.2]])
+    norms = np.array([[5.0, 2.0], [3.0, 7.0], [13.0, 11.0]])
+    maxes = np.array([[4.0, 1.0], [2.0, 6.0], [12.0, 10.0]])
+
+    state.accumulate(
+        indices=indices,
+        scores=scores,
+        selected_output_norms=norms,
+        selected_output_maxes=maxes,
+    )
+
+    report = state.report()
+    assert report["total_tokens"] == 3
+    np.testing.assert_array_equal(report["expert_frequency"], [2, 2, 2])
+    np.testing.assert_array_equal(
+        report["pairwise_expert_frequency"],
+        np.full((3, 3), 4),
+    )
+    np.testing.assert_allclose(report["expert_proba"], [2 / 3, 2 / 3, 2 / 3])
+    np.testing.assert_allclose(report["ean_sum"], [12.0, 14.0, 15.0])
+    np.testing.assert_allclose(report["ean_mean"], [6.0, 7.0, 7.5])
+    np.testing.assert_allclose(report["weighted_ean_sum"], [6.3, 4.9, 8.4])
+    np.testing.assert_allclose(
+        report["weighted_expert_frequency_sum"],
+        [1.1, 1.1, 0.9],
+    )
+    np.testing.assert_allclose(report["reap"], [3.15, 2.45, 4.2])
+    np.testing.assert_allclose(report["max_activations"], [6.0, 10.0, 12.0])
+
+
+def test_accumulate_updates_sequential_batches_with_batch_pairwise_frequency():
+    state = PruningState.initialize(2)
+
+    state.accumulate(
+        indices=np.array([[0]], dtype=np.int64),
+        scores=np.array([[1.0]]),
+        selected_output_norms=np.array([[5.0]]),
+        selected_output_maxes=np.array([[4.0]]),
+    )
+    state.accumulate(
+        indices=np.array([[0], [1]], dtype=np.int64),
+        scores=np.array([[0.3], [0.7]]),
+        selected_output_norms=np.array([[10.0], [2.0]]),
+        selected_output_maxes=np.array([[8.0], [9.0]]),
+    )
+
+    report = state.report()
+    assert report["total_tokens"] == 3
+    np.testing.assert_array_equal(report["expert_frequency"], [2, 1])
+    np.testing.assert_array_equal(
+        report["pairwise_expert_frequency"],
+        [[4, 3], [3, 2]],
+    )
+    np.testing.assert_allclose(report["ean_sum"], [15.0, 2.0])
+    np.testing.assert_allclose(report["ean_mean"], [7.5, 2.0])
+    np.testing.assert_allclose(report["weighted_ean_sum"], [8.0, 1.4])
+    np.testing.assert_allclose(
+        report["weighted_expert_frequency_sum"],
+        [1.3, 0.7],
+    )
+    np.testing.assert_allclose(report["reap"], [4.0, 1.4])
+    np.testing.assert_allclose(report["max_activations"], [8.0, 9.0])
+
+
+def test_accumulate_accepts_router_result():
+    state = PruningState.initialize(2)
+    routing = RouterResult(
+        indices=np.array([[1]], dtype=np.int64),
+        scores=np.array([[0.25]], dtype=np.float32),
+    )
+
+    state.accumulate(
+        routing,
+        selected_output_norms=np.array([[8.0]]),
+        selected_output_maxes=np.array([[7.0]]),
+    )
+
+    report = state.report()
+    assert report["total_tokens"] == 1
+    np.testing.assert_array_equal(report["expert_frequency"], [0, 1])
+    np.testing.assert_allclose(report["weighted_ean_sum"], [0.0, 2.0])
+    np.testing.assert_allclose(report["reap"], [0.0, 2.0])
+
+
+def test_empty_accumulation_is_noop_without_selected_outputs():
+    state = PruningState.initialize(2)
+
+    state.accumulate(
+        indices=np.empty((0, 2), dtype=np.int64),
+        scores=np.empty((0, 2), dtype=np.float32),
+    )
+
+    report = state.report()
+    assert report["total_tokens"] == 0
+    np.testing.assert_array_equal(report["expert_frequency"], [0, 0])
+    np.testing.assert_array_equal(
+        report["pairwise_expert_frequency"],
+        [[0, 0], [0, 0]],
+    )
+    np.testing.assert_allclose(report["ean_sum"], [0.0, 0.0])
+    np.testing.assert_allclose(report["weighted_ean_sum"], [0.0, 0.0])
+    np.testing.assert_allclose(report["max_activations"], [0.0, 0.0])
+
+
+def test_never_selected_experts_report_finite_zeros():
+    state = PruningState.initialize(3)
+
+    state.accumulate(
+        indices=np.array([[0]], dtype=np.int64),
+        scores=np.array([[0.5]]),
+        selected_output_norms=np.array([[4.0]]),
+        selected_output_maxes=np.array([[3.0]]),
+    )
+
+    report = state.report()
+    assert np.isfinite(report["ean_mean"]).all()
+    assert np.isfinite(report["reap"]).all()
+    np.testing.assert_allclose(report["ean_mean"], [4.0, 0.0, 0.0])
+    np.testing.assert_allclose(report["reap"], [2.0, 0.0, 0.0])
+    np.testing.assert_allclose(report["expert_proba"], [1.0, 0.0, 0.0])
+
+
+def test_accumulate_validates_required_stats_and_shapes():
+    state = PruningState.initialize(2)
+
+    with pytest.raises(ValueError, match="selected_outputs or selected_output_norms"):
+        state.accumulate(
+            indices=np.array([[0]], dtype=np.int64),
+            scores=np.array([[1.0]]),
+        )
+
+    with pytest.raises(ValueError, match="same shape"):
+        state.accumulate(
+            indices=np.array([[0]], dtype=np.int64),
+            scores=np.array([1.0]),
+            selected_output_norms=np.array([[1.0]]),
+            selected_output_maxes=np.array([[1.0]]),
+        )
+
+    with pytest.raises(ValueError, match="selected expert indices"):
+        state.accumulate(
+            indices=np.array([[2]], dtype=np.int64),
+            scores=np.array([[1.0]]),
+            selected_output_norms=np.array([[1.0]]),
+            selected_output_maxes=np.array([[1.0]]),
+        )


### PR DESCRIPTION
## Summary
- add an import-safe NumPy pruning accumulator for the MLX backend
- report observer-data keys compatible with REAP pruning metrics
- cover top-k route counting, precomputed stats, empty batches, and import safety

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py
- git diff --check

Closes #3