### PR TITLE
Add MLX layerwise observer

### DIFF
--- a/src/reap/backends/mlx/observer.py
+++ b/src/reap/backends/mlx/observer.py
@@ -1,0 +1,217 @@
+"""Layerwise observer for MLX-backed MoE models.
+
+The MLX observer uses explicit layer replay instead of PyTorch hooks. It records
+only selected expert outputs for pruning metrics and avoids importing optional
+MLX runtime packages until observation is executed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, Callable
+
+from reap.backends.mlx.metrics import PruningState
+from reap.backends.mlx.model_adapters import (
+    Qwen3MoeModelAdapter,
+    get_shared_expert,
+    make_attention_mask,
+)
+from reap.backends.mlx.router import Qwen3MoeRouter
+
+
+logger = logging.getLogger(__name__)
+
+
+def observe_model(
+    model: Any,
+    calibration_sequences: list[Any],
+    config: Mapping[str, Any] | None = None,
+    *,
+    adapter: Any | None = None,
+    debug_memory: bool = False,
+    eval_fn: Callable[[Any], Any] | None = None,
+    mask_fn: Callable[..., Any] | None = None,
+) -> dict[int, dict[str, Any]]:
+    """Collect pruning-compatible observer data with explicit MLX layer replay."""
+    mx = _require_mlx_core()
+    adapter = Qwen3MoeModelAdapter() if adapter is None else adapter
+    config = {} if config is None else config
+    eval_fn = mx.eval if eval_fn is None else eval_fn
+
+    layers = adapter.layers(model)
+    moe_layer_indices = set(adapter.identify_moe_layers(model))
+    embed_tokens = _get_embed_tokens(model)
+
+    accumulators = _initialize_accumulators(
+        layers,
+        moe_layer_indices,
+        adapter=adapter,
+        config=config,
+    )
+
+    for sequence in calibration_sequences:
+        tokens = _batch_tokens(mx, sequence)
+        h = embed_tokens(tokens)
+
+        for layer_idx, layer in enumerate(layers):
+            mask = _attention_mask(
+                h,
+                sequence_length=tokens.shape[-1],
+                mask_fn=mask_fn,
+            )
+            h = _run_attention(layer, h, mask)
+            moe_input = _call_required(layer, "post_attention_layernorm", h)
+
+            if layer_idx in moe_layer_indices:
+                h = h + _observe_moe_layer(
+                    layer,
+                    moe_input,
+                    accumulators[layer_idx],
+                    adapter=adapter,
+                    config=config,
+                )
+            else:
+                dense_mlp = adapter.get_dense_mlp(layer)
+                h = h + dense_mlp(moe_input)
+
+            eval_fn(h)
+            if debug_memory:
+                _log_memory(mx, layer_idx)
+
+    return {layer_idx: state.report() for layer_idx, state in accumulators.items()}
+
+
+def _require_mlx_core():
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "observe_model requires the optional 'mlx' package to execute. "
+            "Install MLX in the active environment before observing."
+        ) from exc
+    return mx
+
+
+def _get_embed_tokens(model: Any) -> Callable[[Any], Any]:
+    model_body = getattr(model, "model", None)
+    embed_tokens = getattr(model_body, "embed_tokens", None)
+    if callable(embed_tokens):
+        return embed_tokens
+
+    embed_tokens = getattr(model, "embed_tokens", None)
+    if callable(embed_tokens):
+        return embed_tokens
+
+    raise ValueError(
+        "Model does not expose an embed_tokens callable at "
+        "model.model.embed_tokens or model.embed_tokens."
+    )
+
+
+def _batch_tokens(mx: Any, sequence: Any) -> Any:
+    input_ids = sequence.get("input_ids") if isinstance(sequence, Mapping) else sequence
+    tokens = mx.array(input_ids)
+
+    if tokens.ndim == 0:
+        raise ValueError("Calibration sequences must contain at least one token.")
+    if tokens.ndim == 1:
+        if tokens.shape[0] == 0:
+            raise ValueError("Calibration sequences must contain at least one token.")
+        return tokens[None, :]
+    if tokens.ndim == 2:
+        if tokens.shape[0] != 1:
+            raise ValueError(
+                "MLX observer only supports unpadded batch-size-1 sequences."
+            )
+        if tokens.shape[1] == 0:
+            raise ValueError("Calibration sequences must contain at least one token.")
+        return tokens
+
+    raise ValueError(
+        "Calibration sequences must have shape [seq] or [1, seq], "
+        f"got {tokens.shape}."
+    )
+
+
+def _initialize_accumulators(
+    layers: Any,
+    moe_layer_indices: set[int],
+    *,
+    adapter: Any,
+    config: Mapping[str, Any],
+) -> dict[int, PruningState]:
+    accumulators: dict[int, PruningState] = {}
+    for layer_idx in sorted(moe_layer_indices):
+        layer_config = adapter.get_layer_config(layers[layer_idx], config)
+        accumulators[layer_idx] = PruningState.initialize(layer_config.num_experts)
+    return accumulators
+
+
+def _attention_mask(
+    hidden_states: Any,
+    *,
+    sequence_length: int,
+    mask_fn: Callable[..., Any] | None,
+) -> Any | None:
+    if mask_fn is not None:
+        return mask_fn(hidden_states, cache=None)
+    if sequence_length == 1:
+        return None
+    return make_attention_mask(hidden_states, cache=None)
+
+
+def _run_attention(layer: Any, h: Any, mask: Any | None) -> Any:
+    normalized = _call_required(layer, "input_layernorm", h)
+    self_attn = getattr(layer, "self_attn", None)
+    if not callable(self_attn):
+        raise ValueError("Layer does not expose a callable self_attn module.")
+
+    attention_output = self_attn(normalized, mask, cache=None)
+    if isinstance(attention_output, tuple):
+        attention_output = attention_output[0]
+    return h + attention_output
+
+
+def _observe_moe_layer(
+    layer: Any,
+    moe_input: Any,
+    state: PruningState,
+    *,
+    adapter: Any,
+    config: Mapping[str, Any],
+) -> Any:
+    moe = adapter.get_moe(layer)
+    routing = Qwen3MoeRouter(moe, config)(moe_input)
+    switch_mlp = getattr(moe, "switch_mlp", None)
+    if not callable(switch_mlp):
+        raise ValueError("MoE layer does not expose a callable switch_mlp module.")
+
+    selected_outputs = switch_mlp(moe_input, routing.indices)
+    state.accumulate(routing, selected_outputs=selected_outputs)
+
+    moe_out = (selected_outputs * routing.scores[..., None]).sum(axis=-2)
+    shared_expert = get_shared_expert(moe)
+    if shared_expert is not None:
+        moe_out = moe_out + shared_expert(moe_input)
+    return moe_out
+
+
+def _call_required(layer: Any, attr: str, h: Any) -> Any:
+    module = getattr(layer, attr, None)
+    if not callable(module):
+        raise ValueError(f"Layer does not expose a callable {attr} module.")
+    return module(h)
+
+
+def _log_memory(mx: Any, layer_idx: int) -> None:
+    memory_parts = []
+    for name in ("get_active_memory", "get_peak_memory", "get_cache_memory"):
+        getter = getattr(mx, name, None)
+        if callable(getter):
+            memory_parts.append(f"{name}={getter()}")
+    if memory_parts:
+        logger.debug("MLX memory after layer %s: %s", layer_idx, ", ".join(memory_parts))
+
+
+__all__ = ["observe_model"]

--- a/tests/test_mlx_observer.py
+++ b/tests/test_mlx_observer.py
@@ -1,0 +1,381 @@
+"""Tests for MLX layerwise observation."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from reap.backends.mlx.observer import observe_model
+
+
+MLX_AVAILABLE = importlib.util.find_spec("mlx") is not None
+
+requires_mlx = pytest.mark.skipif(
+    not MLX_AVAILABLE,
+    reason="MLX is not installed in this environment.",
+)
+
+EXPECTED_PRUNING_KEYS = {
+    "total_tokens",
+    "expert_frequency",
+    "pairwise_expert_frequency",
+    "expert_proba",
+    "ean_sum",
+    "ean_mean",
+    "weighted_ean_sum",
+    "weighted_expert_frequency_sum",
+    "reap",
+    "max_activations",
+}
+
+
+def test_observer_module_import_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX observer import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        from reap.backends.mlx.observer import observe_model
+
+        assert observe_model is not None
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX observer import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+class Identity:
+    def __call__(self, x):
+        return x
+
+
+class ZeroAttention:
+    def __init__(self, mx):
+        self.mx = mx
+        self.masks = []
+
+    def __call__(self, x, mask, cache=None):
+        self.masks.append(mask)
+        return self.mx.zeros_like(x)
+
+
+class TinyEmbed:
+    def __init__(self, mx):
+        self.mx = mx
+
+    def __call__(self, tokens):
+        token_values = tokens.astype(self.mx.float32)
+        return self.mx.stack([token_values, token_values + 1.0], axis=-1)
+
+
+class TinyGate:
+    def __init__(self, mx):
+        self.mx = mx
+
+    def __call__(self, hidden_states):
+        token_values = hidden_states[:, 0]
+        return self.mx.stack(
+            [
+                1.0 - token_values,
+                token_values,
+                self.mx.zeros_like(token_values) - 2.0,
+            ],
+            axis=-1,
+        )
+
+
+class TinySwitchMlp:
+    def __init__(self, mx):
+        self.mx = mx
+
+    def __call__(self, hidden_states, indices):
+        expert_values = indices.astype(self.mx.float32)
+        return self.mx.stack([expert_values + 1.0, expert_values + 2.0], axis=-1)
+
+
+class TinySharedExpert:
+    def __init__(self, mx, value):
+        self.mx = mx
+        self.value = value
+        self.call_count = 0
+
+    def __call__(self, hidden_states):
+        self.call_count += 1
+        return self.mx.ones_like(hidden_states) * self.value
+
+
+class TinyMoeMlp:
+    def __init__(self, mx, *, top_k=1, shared_expert=None):
+        self.num_experts = 3
+        self.top_k = top_k
+        self.norm_topk_prob = False
+        self.gate = TinyGate(mx)
+        self.switch_mlp = TinySwitchMlp(mx)
+        if shared_expert is not None:
+            self.shared_experts = shared_expert
+
+
+class TinyDenseMlp:
+    def __init__(self, mx):
+        self.mx = mx
+        self.inputs = []
+
+    def __call__(self, hidden_states):
+        self.inputs.append(np.asarray(hidden_states))
+        return self.mx.zeros_like(hidden_states)
+
+
+class TinyLayer:
+    def __init__(self, mx, mlp):
+        self.input_layernorm = Identity()
+        self.post_attention_layernorm = Identity()
+        self.self_attn = ZeroAttention(mx)
+        self.mlp = mlp
+
+
+class TinyModel:
+    def __init__(self, mx, layers):
+        self.model = type("TinyModelBody", (), {})()
+        self.model.embed_tokens = TinyEmbed(mx)
+        self.model.layers = layers
+
+
+def _softmax_top_score():
+    values = np.exp(np.array([1.0, 0.0, -2.0]))
+    return values[0] / values.sum()
+
+
+def _mask_recorder():
+    calls = []
+
+    def mask_fn(hidden_states, cache=None):
+        calls.append((hidden_states.shape, cache))
+        return {"shape": hidden_states.shape}
+
+    return calls, mask_fn
+
+
+@requires_mlx
+def test_observe_model_reports_pruning_keys_and_manual_values():
+    import mlx.core as mx
+
+    model = TinyModel(mx, [TinyLayer(mx, TinyMoeMlp(mx, top_k=1))])
+    mask_calls, mask_fn = _mask_recorder()
+
+    observer_data = observe_model(
+        model,
+        [{"input_ids": [0, 1]}],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+        mask_fn=mask_fn,
+    )
+
+    assert set(observer_data) == {0}
+    report = observer_data[0]
+    assert set(report) == EXPECTED_PRUNING_KEYS
+    assert len(mask_calls) == 1
+
+    top_score = _softmax_top_score()
+    norm0 = np.sqrt(5.0)
+    norm1 = np.sqrt(13.0)
+
+    assert report["total_tokens"] == 2
+    np.testing.assert_array_equal(report["expert_frequency"], [1, 1, 0])
+    np.testing.assert_array_equal(
+        report["pairwise_expert_frequency"],
+        [[2, 2, 1], [2, 2, 1], [1, 1, 0]],
+    )
+    np.testing.assert_allclose(report["expert_proba"], [0.5, 0.5, 0.0])
+    np.testing.assert_allclose(report["ean_sum"], [norm0, norm1, 0.0])
+    np.testing.assert_allclose(report["ean_mean"], [norm0, norm1, 0.0])
+    np.testing.assert_allclose(
+        report["weighted_ean_sum"],
+        [norm0 * top_score, norm1 * top_score, 0.0],
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        report["weighted_expert_frequency_sum"],
+        [top_score, top_score, 0.0],
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        report["reap"],
+        [norm0 * top_score, norm1 * top_score, 0.0],
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(report["max_activations"], [2.0, 3.0, 0.0])
+
+
+@requires_mlx
+def test_observe_model_counts_topk_routes_separately_from_tokens():
+    import mlx.core as mx
+
+    model = TinyModel(mx, [TinyLayer(mx, TinyMoeMlp(mx, top_k=2))])
+    _, mask_fn = _mask_recorder()
+
+    observer_data = observe_model(
+        model,
+        [[0, 1]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+        mask_fn=mask_fn,
+    )
+
+    report = observer_data[0]
+    assert report["total_tokens"] == 2
+    assert report["expert_frequency"].sum() == 4
+    np.testing.assert_array_equal(report["expert_frequency"], [2, 2, 0])
+
+
+@requires_mlx
+def test_observe_model_reports_only_moe_layers_in_partial_model():
+    import mlx.core as mx
+
+    layers = [
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyMoeMlp(mx, top_k=1)),
+        TinyLayer(mx, TinyDenseMlp(mx)),
+    ]
+    model = TinyModel(mx, layers)
+
+    observer_data = observe_model(
+        model,
+        [[0]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+    )
+
+    assert set(observer_data) == {1}
+
+
+@requires_mlx
+def test_observe_model_calls_mask_fn_for_sequence_length_greater_than_one():
+    import mlx.core as mx
+
+    layers = [
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyMoeMlp(mx, top_k=1)),
+    ]
+    model = TinyModel(mx, layers)
+    mask_calls, mask_fn = _mask_recorder()
+
+    observe_model(
+        model,
+        [[0, 1]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+        mask_fn=mask_fn,
+    )
+
+    assert mask_calls == [((1, 2, 2), None), ((1, 2, 2), None)]
+    assert layers[0].self_attn.masks[0] == {"shape": (1, 2, 2)}
+
+
+@requires_mlx
+def test_observe_model_calls_eval_fn_after_each_layer():
+    import mlx.core as mx
+
+    layers = [
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyMoeMlp(mx, top_k=1)),
+        TinyLayer(mx, TinyDenseMlp(mx)),
+    ]
+    model = TinyModel(mx, layers)
+    eval_calls = []
+
+    observe_model(
+        model,
+        [[0, 1]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+        mask_fn=lambda h, cache=None: None,
+        eval_fn=lambda h: eval_calls.append(h.shape),
+    )
+
+    assert eval_calls == [(1, 2, 2), (1, 2, 2), (1, 2, 2)]
+
+
+@requires_mlx
+def test_observe_model_adds_shared_expert_to_hidden_flow_only():
+    import mlx.core as mx
+
+    shared_expert = TinySharedExpert(mx, value=5.0)
+    dense_mlp = TinyDenseMlp(mx)
+    model = TinyModel(
+        mx,
+        [
+            TinyLayer(mx, TinyMoeMlp(mx, top_k=1, shared_expert=shared_expert)),
+            TinyLayer(mx, dense_mlp),
+        ],
+    )
+
+    observer_data = observe_model(
+        model,
+        [[0]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+    )
+
+    top_score = _softmax_top_score()
+    expected_hidden = np.array([[[0.0, 1.0]]]) + (
+        np.array([[[1.0, 2.0]]]) * top_score
+    ) + np.array([[[5.0, 5.0]]])
+
+    assert shared_expert.call_count == 1
+    np.testing.assert_allclose(dense_mlp.inputs[0], expected_hidden, rtol=1e-6)
+    np.testing.assert_allclose(observer_data[0]["ean_sum"], [np.sqrt(5.0), 0.0, 0.0])
+
+
+@requires_mlx
+def test_observe_model_rejects_empty_calibration_sequence():
+    import mlx.core as mx
+
+    model = TinyModel(mx, [TinyLayer(mx, TinyMoeMlp(mx, top_k=1))])
+
+    with pytest.raises(ValueError, match="at least one token"):
+        observe_model(
+            model,
+            [[]],
+            {"num_experts": 3, "num_experts_per_tok": 1},
+        )


### PR DESCRIPTION
## Summary
- add import-safe MLX layerwise observer with explicit replay
- capture selected expert outputs and accumulate pruning-compatible metrics
- add synthetic tests for MoE routing, dense layers, masks, eval boundaries, and shared experts

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py tests/test_mlx_model_adapters.py tests/test_mlx_observer.py
- PYTHONPATH=src .venv/bin/python -m py_compile src/reap/backends/mlx/observer.py tests/test_mlx_observer.py
- git diff --check

Closes #5