### PR TITLE
Add MLX expert pruning

### DIFF
--- a/src/reap/backends/mlx/prune.py
+++ b/src/reap/backends/mlx/prune.py
@@ -1,0 +1,345 @@
+"""Expert pruning for adapter-described MLX MoE modules.
+
+This module mutates live MLX-LM-style modules by slicing expert-stacked arrays
+on their first dimension. It intentionally avoids importing MLX, MLX-LM, Torch,
+or vLLM at module import time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+import numpy as np
+
+from reap.backends.mlx.model_adapters import (
+    Qwen3MoeModelAdapter,
+    update_qwen3_moe_config,
+)
+
+
+_PRUNE_METHOD_ALIASES = {
+    "frequency": "expert_frequency",
+    "weighted_frequency_sum": "weighted_expert_frequency_sum",
+}
+
+_SUPPORTED_PRUNE_METHODS = {
+    "expert_frequency",
+    "ean_sum",
+    "ean_mean",
+    "weighted_ean_sum",
+    "weighted_expert_frequency_sum",
+    "reap",
+    "max_activations",
+}
+
+_SLICE_FIELD_NAMES = ("weight", "scales", "biases", "bias")
+_SWITCH_PROJECTION_NAMES = ("gate_proj", "up_proj", "down_proj")
+_TOP_K_ATTRS = ("top_k", "num_experts_per_tok", "k")
+
+
+def prune_experts(
+    model: Any,
+    config: MutableMapping[str, Any],
+    observer_data: Mapping[int, Mapping[str, Any]],
+    prune_method: str,
+    compression_ratio: float,
+    *,
+    adapter: Any | None = None,
+) -> dict[int, np.ndarray]:
+    """Prune adapter-discovered MLX MoE experts in place.
+
+    Returns a mapping from layer index to ascending retained expert indices.
+    """
+    adapter = Qwen3MoeModelAdapter() if adapter is None else adapter
+    _validate_adapter(adapter)
+    _validate_compression_ratio(compression_ratio)
+
+    layers = adapter.layers(model)
+    keep_by_layer: dict[int, np.ndarray] = {}
+    config_num_experts: int | None = None
+    config_top_k: int | None = None
+
+    for layer_idx in adapter.identify_moe_layers(model):
+        if layer_idx not in observer_data:
+            raise ValueError(
+                f"Missing observer data for MoE layer {layer_idx}. "
+                f"Available layers: {sorted(observer_data)}."
+            )
+
+        layer = layers[layer_idx]
+        layer_config = adapter.get_layer_config(layer, config)
+        retained_count = _retained_expert_count(
+            layer_config.num_experts,
+            compression_ratio,
+        )
+        saliency = _saliency_scores(
+            observer_data[layer_idx],
+            prune_method,
+            num_experts=layer_config.num_experts,
+            layer_idx=layer_idx,
+        )
+        keep_indices = compute_keep_indices(saliency, retained_count)
+
+        _prune_qwen3_moe_layer(
+            adapter.get_moe(layer),
+            keep_indices,
+            num_experts=layer_config.num_experts,
+            old_top_k=layer_config.top_k,
+            layer_idx=layer_idx,
+        )
+        keep_by_layer[layer_idx] = keep_indices
+
+        new_top_k = min(layer_config.top_k, retained_count)
+        if config_num_experts is None:
+            config_num_experts = retained_count
+            config_top_k = new_top_k
+        elif config_num_experts != retained_count:
+            raise ValueError(
+                "Qwen3-MoE config update requires all pruned layers to retain "
+                f"the same expert count. Layer {layer_idx} retained "
+                f"{retained_count}, expected {config_num_experts}."
+            )
+        else:
+            config_top_k = min(config_top_k or new_top_k, new_top_k)
+
+    if config_num_experts is not None:
+        update_qwen3_moe_config(
+            config,
+            num_experts=config_num_experts,
+            top_k=config_top_k or config_num_experts,
+        )
+
+    return keep_by_layer
+
+
+def resolve_prune_method(prune_method: str) -> str:
+    """Return the observer-data key for a supported prune method or alias."""
+    resolved = _PRUNE_METHOD_ALIASES.get(prune_method, prune_method)
+    if resolved not in _SUPPORTED_PRUNE_METHODS:
+        supported = sorted(_SUPPORTED_PRUNE_METHODS | set(_PRUNE_METHOD_ALIASES))
+        raise ValueError(
+            f"Unsupported prune method {prune_method!r}. "
+            f"Supported methods: {supported}."
+        )
+    return resolved
+
+
+def compute_keep_indices(saliency: Any, retained_count: int) -> np.ndarray:
+    """Keep the highest-saliency experts and return them in ascending order."""
+    saliency_array = np.asarray(saliency, dtype=np.float64)
+    if saliency_array.ndim != 1:
+        raise ValueError(
+            "saliency scores must be a one-dimensional array, got "
+            f"shape {saliency_array.shape}."
+        )
+    retained_count = int(retained_count)
+    if retained_count < 1 or retained_count > saliency_array.shape[0]:
+        raise ValueError(
+            "retained_count must be in [1, num_experts], got "
+            f"{retained_count} for {saliency_array.shape[0]} experts."
+        )
+    if np.isnan(saliency_array).any():
+        raise ValueError("saliency scores must not contain NaN values.")
+
+    expert_ids = np.arange(saliency_array.shape[0])
+    ranked = np.lexsort((expert_ids, -saliency_array))
+    return np.sort(ranked[:retained_count]).astype(np.int64, copy=False)
+
+
+def slice_first_dim(
+    module: Any,
+    keep_indices: np.ndarray,
+    *,
+    num_experts: int,
+    required: bool = False,
+    field_names: tuple[str, ...] = _SLICE_FIELD_NAMES,
+) -> bool:
+    """Slice present module fields on dimension 0.
+
+    Returns ``True`` if at least one field was sliced.
+    """
+    sliced_any = False
+    keep_list = _keep_list(keep_indices)
+
+    for field_name in field_names:
+        value = _get_module_value(module, field_name)
+        if value is None:
+            continue
+        _validate_first_dim(
+            value,
+            field_name=field_name,
+            num_experts=num_experts,
+        )
+        _set_module_value(module, field_name, value[keep_list])
+        sliced_any = True
+
+    if required and not sliced_any:
+        raise ValueError(
+            "Expected module to expose at least one sliceable field from "
+            f"{field_names}."
+        )
+    return sliced_any
+
+
+def _validate_adapter(adapter: Any) -> None:
+    adapter_name = getattr(adapter, "adapter_name", None)
+    if adapter_name != "qwen3_moe":
+        raise ValueError(
+            "MLX expert pruning currently supports the qwen3_moe adapter only; "
+            f"got {adapter_name!r}."
+        )
+
+
+def _validate_compression_ratio(compression_ratio: float) -> None:
+    try:
+        ratio = float(compression_ratio)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("compression_ratio must be a number in [0, 1).") from exc
+
+    if ratio < 0.0 or ratio >= 1.0:
+        raise ValueError(
+            f"compression_ratio must be in [0, 1), got {compression_ratio}."
+        )
+
+
+def _retained_expert_count(num_experts: int, compression_ratio: float) -> int:
+    num_experts = int(num_experts)
+    num_to_prune = int(num_experts * float(compression_ratio))
+    return max(num_experts - num_to_prune, 1)
+
+
+def _saliency_scores(
+    layer_observer_data: Mapping[str, Any],
+    prune_method: str,
+    *,
+    num_experts: int,
+    layer_idx: int,
+) -> np.ndarray:
+    resolved_method = resolve_prune_method(prune_method)
+    if resolved_method not in layer_observer_data:
+        raise ValueError(
+            f"Prune method {prune_method!r} resolved to {resolved_method!r}, "
+            f"but that key is missing from observer data for layer {layer_idx}. "
+            f"Available keys: {sorted(layer_observer_data)}."
+        )
+
+    scores = np.asarray(layer_observer_data[resolved_method], dtype=np.float64)
+    if scores.ndim != 1:
+        raise ValueError(
+            f"Observer metric {resolved_method!r} for layer {layer_idx} must be "
+            f"one-dimensional, got shape {scores.shape}."
+        )
+    if scores.shape[0] != num_experts:
+        raise ValueError(
+            f"Observer metric {resolved_method!r} for layer {layer_idx} has "
+            f"{scores.shape[0]} scores, expected {num_experts}."
+        )
+    return scores
+
+
+def _prune_qwen3_moe_layer(
+    moe: Any,
+    keep_indices: np.ndarray,
+    *,
+    num_experts: int,
+    old_top_k: int,
+    layer_idx: int,
+) -> None:
+    switch_mlp = getattr(moe, "switch_mlp", None)
+    if switch_mlp is None:
+        raise ValueError(f"MoE layer {layer_idx} does not expose switch_mlp.")
+
+    for projection_name in _SWITCH_PROJECTION_NAMES:
+        projection = getattr(switch_mlp, projection_name, None)
+        if projection is None:
+            raise ValueError(
+                f"MoE layer {layer_idx} switch_mlp is missing "
+                f"{projection_name}."
+            )
+        if _get_module_value(projection, "weight") is None:
+            raise ValueError(
+                f"MoE layer {layer_idx} switch_mlp.{projection_name} is "
+                "missing required weight."
+            )
+        slice_first_dim(
+            projection,
+            keep_indices,
+            num_experts=num_experts,
+            required=True,
+        )
+
+    gate = getattr(moe, "gate", None)
+    if gate is None:
+        raise ValueError(f"MoE layer {layer_idx} does not expose a gate.")
+    if _get_module_value(gate, "weight") is None:
+        raise ValueError(f"MoE layer {layer_idx} gate is missing required weight.")
+    slice_first_dim(
+        gate,
+        keep_indices,
+        num_experts=num_experts,
+        required=True,
+        field_names=("weight", "bias", "e_score_correction_bias"),
+    )
+
+    retained_count = len(keep_indices)
+    new_top_k = min(int(old_top_k), retained_count)
+    _update_runtime_attrs(moe, gate, retained_count=retained_count, top_k=new_top_k)
+
+
+def _update_runtime_attrs(
+    moe: Any,
+    gate: Any,
+    *,
+    retained_count: int,
+    top_k: int,
+) -> None:
+    setattr(moe, "num_experts", retained_count)
+    for attr in _TOP_K_ATTRS:
+        if hasattr(moe, attr):
+            setattr(moe, attr, top_k)
+
+    for attr in ("num_experts", "n_routed_experts"):
+        if hasattr(gate, attr):
+            setattr(gate, attr, retained_count)
+    if hasattr(gate, "top_k"):
+        setattr(gate, "top_k", top_k)
+
+
+def _get_module_value(module: Any, field_name: str) -> Any | None:
+    getter = getattr(module, "get", None)
+    if callable(getter):
+        try:
+            value = getter(field_name)
+        except (KeyError, TypeError, AttributeError):
+            value = None
+        if value is not None:
+            return value
+    return getattr(module, field_name, None)
+
+
+def _set_module_value(module: Any, field_name: str, value: Any) -> None:
+    setattr(module, field_name, value)
+
+
+def _validate_first_dim(value: Any, *, field_name: str, num_experts: int) -> None:
+    shape = getattr(value, "shape", None)
+    if shape is None or len(shape) < 1:
+        raise ValueError(f"{field_name} must expose a non-empty shape.")
+    if int(shape[0]) != int(num_experts):
+        raise ValueError(
+            f"{field_name} first dimension must match num_experts={num_experts}, "
+            f"got shape {shape}."
+        )
+
+
+def _keep_list(keep_indices: np.ndarray) -> list[int]:
+    return [int(idx) for idx in np.asarray(keep_indices, dtype=np.int64).tolist()]
+
+
+__all__ = [
+    "compute_keep_indices",
+    "prune_experts",
+    "resolve_prune_method",
+    "slice_first_dim",
+]

--- a/tests/test_mlx_prune.py
+++ b/tests/test_mlx_prune.py
@@ -1,0 +1,384 @@
+"""Tests for MLX expert pruning mutation."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from reap.backends.mlx.prune import (
+    compute_keep_indices,
+    prune_experts,
+    resolve_prune_method,
+    slice_first_dim,
+)
+
+
+MLX_AVAILABLE = importlib.util.find_spec("mlx") is not None
+
+requires_mlx = pytest.mark.skipif(
+    not MLX_AVAILABLE,
+    reason="MLX is not installed in this environment.",
+)
+
+
+def test_prune_module_import_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX prune import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        from reap.backends.mlx.prune import prune_experts
+
+        assert prune_experts is not None
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX prune import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+class SliceModule:
+    def __init__(self, num_experts: int, offset: int):
+        base = np.arange(num_experts * 6, dtype=np.float32).reshape(
+            num_experts,
+            2,
+            3,
+        )
+        self.weight = base + offset
+        self.scales = (
+            np.arange(num_experts * 2, dtype=np.float32).reshape(num_experts, 2)
+            + offset
+            + 100
+        )
+        self.biases = (
+            np.arange(num_experts * 2, dtype=np.float32).reshape(num_experts, 2)
+            + offset
+            + 200
+        )
+        self.bias = (
+            np.arange(num_experts * 2, dtype=np.float32).reshape(num_experts, 2)
+            + offset
+            + 300
+        )
+
+    def get(self, name: str):
+        return getattr(self, name, None)
+
+
+class TinySwitchMlp:
+    def __init__(self, num_experts: int):
+        self.gate_proj = SliceModule(num_experts, 0)
+        self.up_proj = SliceModule(num_experts, 1000)
+        self.down_proj = SliceModule(num_experts, 2000)
+
+    def __call__(self, hidden_states, indices):
+        selected_values = self.gate_proj.weight[indices, 0, 0]
+        return np.stack([selected_values, selected_values + 1.0], axis=-1)
+
+
+class TinyGate:
+    def __init__(self, num_experts: int):
+        self.weight = (
+            np.arange(num_experts * 2, dtype=np.float32).reshape(num_experts, 2)
+            + 4000
+        )
+        self.bias = np.arange(num_experts, dtype=np.float32) + 5000
+        self.e_score_correction_bias = (
+            np.arange(num_experts, dtype=np.float32) + 6000
+        )
+        self.num_experts = num_experts
+        self.n_routed_experts = num_experts
+        self.top_k = 3
+
+
+class TinyMoe:
+    def __init__(self, num_experts: int = 4, top_k: int = 3):
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.num_experts_per_tok = top_k
+        self.norm_topk_prob = False
+        self.gate = TinyGate(num_experts)
+        self.switch_mlp = TinySwitchMlp(num_experts)
+
+    def __call__(self, hidden_states, indices):
+        selected_outputs = self.switch_mlp(hidden_states, indices)
+        scores = np.ones(indices.shape, dtype=np.float32) / indices.shape[-1]
+        return (selected_outputs * scores[..., None]).sum(axis=-2)
+
+
+def make_model(num_experts: int = 4, top_k: int = 3):
+    moe = TinyMoe(num_experts=num_experts, top_k=top_k)
+    return SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(mlp=moe)]),
+    )
+
+
+def qwen_config(num_experts: int = 4, top_k: int = 3):
+    return {
+        "num_experts": num_experts,
+        "num_experts_per_tok": top_k,
+        "top_k": top_k,
+        "norm_topk_prob": False,
+    }
+
+
+def test_resolve_prune_method_aliases_and_rejects_unknown_method():
+    assert resolve_prune_method("frequency") == "expert_frequency"
+    assert (
+        resolve_prune_method("weighted_frequency_sum")
+        == "weighted_expert_frequency_sum"
+    )
+    assert resolve_prune_method("reap") == "reap"
+
+    with pytest.raises(ValueError, match="Unsupported prune method"):
+        resolve_prune_method("ean_ca")
+
+
+def test_compute_keep_indices_keeps_highest_saliency_in_ascending_order():
+    keep = compute_keep_indices(np.array([0.1, 0.9, 0.2, 0.8]), 2)
+
+    np.testing.assert_array_equal(keep, np.array([1, 3]))
+
+
+def test_prune_experts_slices_qwen_switch_router_metadata_and_config():
+    model = make_model(num_experts=4, top_k=3)
+    config = qwen_config(num_experts=4, top_k=3)
+    moe = model.model.layers[0].mlp
+    keep = np.array([1, 3])
+
+    originals = {
+        "gate_proj_weight": moe.switch_mlp.gate_proj.weight.copy(),
+        "gate_proj_scales": moe.switch_mlp.gate_proj.scales.copy(),
+        "gate_proj_biases": moe.switch_mlp.gate_proj.biases.copy(),
+        "gate_proj_bias": moe.switch_mlp.gate_proj.bias.copy(),
+        "up_proj_weight": moe.switch_mlp.up_proj.weight.copy(),
+        "down_proj_weight": moe.switch_mlp.down_proj.weight.copy(),
+        "gate_weight": moe.gate.weight.copy(),
+        "gate_bias": moe.gate.bias.copy(),
+        "gate_correction": moe.gate.e_score_correction_bias.copy(),
+    }
+
+    keep_by_layer = prune_experts(
+        model,
+        config,
+        {0: {"reap": np.array([0.1, 0.9, 0.2, 0.8])}},
+        "reap",
+        0.5,
+    )
+
+    np.testing.assert_array_equal(keep_by_layer[0], keep)
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.weight,
+        originals["gate_proj_weight"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.scales,
+        originals["gate_proj_scales"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.biases,
+        originals["gate_proj_biases"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.bias,
+        originals["gate_proj_bias"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.up_proj.weight,
+        originals["up_proj_weight"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.down_proj.weight,
+        originals["down_proj_weight"][keep],
+    )
+    np.testing.assert_array_equal(moe.gate.weight, originals["gate_weight"][keep])
+    np.testing.assert_array_equal(moe.gate.bias, originals["gate_bias"][keep])
+    np.testing.assert_array_equal(
+        moe.gate.e_score_correction_bias,
+        originals["gate_correction"][keep],
+    )
+
+    assert moe.num_experts == 2
+    assert moe.top_k == 2
+    assert moe.num_experts_per_tok == 2
+    assert moe.gate.num_experts == 2
+    assert moe.gate.n_routed_experts == 2
+    assert moe.gate.top_k == 2
+    assert config["num_experts"] == 2
+    assert config["num_experts_per_tok"] == 2
+    assert config["top_k"] == 2
+
+
+def test_prune_experts_accepts_weighted_frequency_alias():
+    model = make_model(num_experts=3, top_k=2)
+    config = qwen_config(num_experts=3, top_k=2)
+
+    keep_by_layer = prune_experts(
+        model,
+        config,
+        {0: {"weighted_expert_frequency_sum": np.array([0.1, 0.9, 0.8])}},
+        "weighted_frequency_sum",
+        1 / 3,
+    )
+
+    np.testing.assert_array_equal(keep_by_layer[0], np.array([1, 2]))
+    assert config["num_experts"] == 2
+    assert config["num_experts_per_tok"] == 2
+
+
+@requires_mlx
+def test_slice_first_dim_handles_mlx_arrays():
+    import mlx.core as mx
+
+    module = SimpleNamespace(
+        weight=mx.array([[0, 1], [2, 3], [4, 5]]),
+        scales=mx.array([[10], [11], [12]]),
+    )
+
+    slice_first_dim(
+        module,
+        np.array([0, 2]),
+        num_experts=3,
+        field_names=("weight", "scales"),
+    )
+    mx.eval(module.weight, module.scales)
+
+    assert module.weight.tolist() == [[0, 1], [4, 5]]
+    assert module.scales.tolist() == [[10], [12]]
+
+
+def test_pruned_tiny_moe_forward_keeps_output_shape():
+    model = make_model(num_experts=4, top_k=3)
+    config = qwen_config(num_experts=4, top_k=3)
+    moe = model.model.layers[0].mlp
+
+    prune_experts(
+        model,
+        config,
+        {0: {"expert_frequency": np.array([1, 4, 2, 3])}},
+        "frequency",
+        0.5,
+    )
+
+    hidden_states = np.ones((1, 2, 2), dtype=np.float32)
+    indices = np.array([[[0, 1], [1, 0]]], dtype=np.int64)
+    output = moe(hidden_states, indices)
+
+    assert output.shape == hidden_states.shape
+
+
+@pytest.mark.parametrize("compression_ratio", [-0.1, 1.0])
+def test_prune_experts_rejects_invalid_compression_ratio(compression_ratio):
+    model = make_model()
+    config = qwen_config()
+
+    with pytest.raises(ValueError, match="compression_ratio"):
+        prune_experts(
+            model,
+            config,
+            {0: {"reap": np.array([0.1, 0.9, 0.2, 0.8])}},
+            "reap",
+            compression_ratio,
+        )
+
+
+def test_prune_experts_rejects_missing_observer_layer_data():
+    model = make_model()
+    config = qwen_config()
+
+    with pytest.raises(ValueError, match="Missing observer data for MoE layer 0"):
+        prune_experts(model, config, {}, "reap", 0.5)
+
+
+def test_prune_experts_rejects_wrong_saliency_length():
+    model = make_model(num_experts=4)
+    config = qwen_config(num_experts=4)
+
+    with pytest.raises(ValueError, match="expected 4"):
+        prune_experts(
+            model,
+            config,
+            {0: {"reap": np.array([0.1, 0.9, 0.2])}},
+            "reap",
+            0.5,
+        )
+
+
+def test_prune_experts_rejects_missing_switch_projection():
+    model = make_model()
+    config = qwen_config()
+    delattr(model.model.layers[0].mlp.switch_mlp, "up_proj")
+
+    with pytest.raises(ValueError, match="missing up_proj"):
+        prune_experts(
+            model,
+            config,
+            {0: {"reap": np.array([0.1, 0.9, 0.2, 0.8])}},
+            "reap",
+            0.5,
+        )
+
+
+def test_prune_experts_rejects_slice_field_with_wrong_first_dimension():
+    model = make_model(num_experts=4)
+    config = qwen_config(num_experts=4)
+    model.model.layers[0].mlp.switch_mlp.gate_proj.scales = np.zeros(
+        (3, 2),
+        dtype=np.float32,
+    )
+
+    with pytest.raises(ValueError, match="scales first dimension"):
+        prune_experts(
+            model,
+            config,
+            {0: {"reap": np.array([0.1, 0.9, 0.2, 0.8])}},
+            "reap",
+            0.5,
+        )


### PR DESCRIPTION
## Summary
- add import-safe MLX expert pruning for Qwen3-style adapter-described MoE layers
- slice switch/router tensors plus quant metadata and update runtime/config expert counts
- cover pruning aliases, shape validation, config updates, and synthetic forward smoke tests

Closes #6

## Tests
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py tests/test_mlx_model_adapters.py tests/test_mlx_observer.py tests/test_mlx_prune.py
- PYTHONPATH=src .venv/bin/python -m py_compile src/reap/backends/mlx/prune.py tests/test_mlx_prune.py
- git diff --check HEAD~1..HEAD