### PR TITLE
Add MLX save reload validation

### DIFF
--- a/src/reap/backends/mlx/save.py
+++ b/src/reap/backends/mlx/save.py
@@ -1,0 +1,321 @@
+"""Save/reload validation helpers for pruned MLX models.
+
+This module is intentionally import-light. MLX-LM is imported only when the
+default save, load, or generation helpers are executed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from reap.backends.mlx.model_adapters import Qwen3MoeModelAdapter
+
+
+_WEIGHT_PATTERNS = ("*.safetensors", "*.npz")
+
+
+@dataclass(frozen=True)
+class SaveReloadResult:
+    """Result of saving, reloading, and validating a pruned MLX model."""
+
+    output_dir: Path
+    reloaded_model: Any
+    reloaded_tokenizer: Any
+    reloaded_config: Mapping[str, Any]
+    expected_expert_count: int
+    smoke_result: Any = None
+
+
+def save_pruned_model(
+    model: Any,
+    tokenizer: Any,
+    config: Mapping[str, Any],
+    output_dir: str | Path,
+    original_model_name: str | Path,
+    *,
+    adapter: Any | None = None,
+    expected_expert_count: int | None = None,
+    smoke_fn: Callable[[Any, Any, Mapping[str, Any]], Any] | None = None,
+    load_fn: Callable[..., Any] | None = None,
+    save_fn: Callable[..., Any] | None = None,
+) -> SaveReloadResult:
+    """Save a pruned model, reload it, and validate the reloaded artifact."""
+    adapter = Qwen3MoeModelAdapter() if adapter is None else adapter
+    output_path = _prepare_output_dir(output_dir)
+    expected_count = _expected_expert_count(config, expected_expert_count)
+    save_fn = _default_save_fn() if save_fn is None else save_fn
+    load_fn = _default_load_fn() if load_fn is None else load_fn
+
+    try:
+        save_fn(
+            dst_path=str(output_path),
+            src_path_or_repo=str(original_model_name),
+            model=model,
+            tokenizer=tokenizer,
+            config=config,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to save pruned MLX model to {output_path}."
+        ) from exc
+
+    _validate_saved_artifacts(output_path)
+
+    reloaded_model, reloaded_tokenizer, reloaded_config = _load_reloaded_model(
+        load_fn,
+        output_path,
+    )
+    _validate_reloaded_config(reloaded_config, expected_count)
+    _validate_reloaded_model_shapes(
+        reloaded_model,
+        reloaded_config,
+        adapter=adapter,
+        expected_expert_count=expected_count,
+    )
+
+    smoke_result = None
+    if smoke_fn is not None:
+        smoke_result = smoke_fn(
+            reloaded_model,
+            reloaded_tokenizer,
+            reloaded_config,
+        )
+
+    return SaveReloadResult(
+        output_dir=output_path,
+        reloaded_model=reloaded_model,
+        reloaded_tokenizer=reloaded_tokenizer,
+        reloaded_config=reloaded_config,
+        expected_expert_count=expected_count,
+        smoke_result=smoke_result,
+    )
+
+
+def generation_smoke(
+    model: Any,
+    tokenizer: Any,
+    config: Mapping[str, Any] | None = None,
+    *,
+    prompt: str = "What is your name?",
+    max_tokens: int = 16,
+    generate_fn: Callable[..., Any] | None = None,
+) -> Any:
+    """Run a short MLX-LM generation smoke test."""
+    del config
+    generate_fn = _default_generate_fn() if generate_fn is None else generate_fn
+
+    if getattr(tokenizer, "chat_template", None) and hasattr(
+        tokenizer,
+        "apply_chat_template",
+    ):
+        messages = [{"role": "user", "content": prompt}]
+        prompt = tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+        )
+
+    return generate_fn(
+        model,
+        tokenizer,
+        prompt=prompt,
+        max_tokens=max_tokens,
+    )
+
+
+def _prepare_output_dir(output_dir: str | Path) -> Path:
+    output_path = Path(output_dir)
+    if output_path.exists() and not output_path.is_dir():
+        raise OSError(f"Output path exists and is not a directory: {output_path}")
+    output_path.mkdir(parents=True, exist_ok=True)
+    return output_path
+
+
+def _expected_expert_count(
+    config: Mapping[str, Any],
+    expected_expert_count: int | None,
+) -> int:
+    value = expected_expert_count
+    if value is None:
+        value = config.get("num_experts")
+    if value is None:
+        raise ValueError(
+            "expected_expert_count is required when config['num_experts'] "
+            "is missing."
+        )
+    value = int(value)
+    if value < 1:
+        raise ValueError(f"expected_expert_count must be positive, got {value}.")
+    return value
+
+
+def _default_save_fn() -> Callable[..., Any]:
+    try:
+        from mlx_lm import utils
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "save_pruned_model requires the optional 'mlx_lm' package when "
+            "save_fn is not provided."
+        ) from exc
+    return utils.save
+
+
+def _default_load_fn() -> Callable[..., Any]:
+    try:
+        from mlx_lm import load
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "save_pruned_model requires the optional 'mlx_lm' package when "
+            "load_fn is not provided."
+        ) from exc
+    return load
+
+
+def _default_generate_fn() -> Callable[..., Any]:
+    try:
+        from mlx_lm import generate
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "generation_smoke requires the optional 'mlx_lm' package when "
+            "generate_fn is not provided."
+        ) from exc
+    return generate
+
+
+def _validate_saved_artifacts(output_dir: Path) -> None:
+    if not (output_dir / "config.json").is_file():
+        raise RuntimeError(f"Saved MLX model is missing config.json in {output_dir}.")
+
+    if not any(output_dir.glob(pattern) for pattern in _WEIGHT_PATTERNS):
+        raise RuntimeError(
+            "Saved MLX model is missing weight artifacts matching "
+            f"{_WEIGHT_PATTERNS} in {output_dir}."
+        )
+
+
+def _load_reloaded_model(load_fn: Callable[..., Any], output_dir: Path) -> tuple[
+    Any,
+    Any,
+    Mapping[str, Any],
+]:
+    try:
+        reload_result = load_fn(str(output_dir), return_config=True)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to reload pruned MLX model from {output_dir}."
+        ) from exc
+
+    if not isinstance(reload_result, tuple) or len(reload_result) != 3:
+        raise ValueError(
+            "Expected mlx_lm.load(..., return_config=True) to return "
+            "(model, tokenizer, config)."
+        )
+
+    reloaded_model, reloaded_tokenizer, reloaded_config = reload_result
+    if not isinstance(reloaded_config, Mapping):
+        raise ValueError("Reloaded config must be a mapping.")
+    return reloaded_model, reloaded_tokenizer, reloaded_config
+
+
+def _validate_reloaded_config(
+    reloaded_config: Mapping[str, Any],
+    expected_expert_count: int,
+) -> None:
+    actual = reloaded_config.get("num_experts")
+    if actual is None:
+        raise ValueError("Reloaded config is missing 'num_experts'.")
+    actual = int(actual)
+    if actual != expected_expert_count:
+        raise ValueError(
+            "Reloaded config expert count mismatch: "
+            f"expected {expected_expert_count}, got {actual}."
+        )
+
+
+def _validate_reloaded_model_shapes(
+    reloaded_model: Any,
+    reloaded_config: Mapping[str, Any],
+    *,
+    adapter: Any,
+    expected_expert_count: int,
+) -> None:
+    layer_indices = adapter.identify_moe_layers(reloaded_model)
+    if not layer_indices:
+        raise ValueError("Reloaded model has no adapter-visible MoE layers.")
+
+    layers = adapter.layers(reloaded_model)
+    for layer_idx in layer_indices:
+        layer = layers[layer_idx]
+        layer_config = adapter.get_layer_config(layer, reloaded_config)
+        if layer_config.num_experts != expected_expert_count:
+            raise ValueError(
+                f"Reloaded layer {layer_idx} expert count mismatch: expected "
+                f"{expected_expert_count}, got {layer_config.num_experts}."
+            )
+        _validate_qwen3_shapes(
+            adapter.get_moe(layer),
+            expected_expert_count=expected_expert_count,
+            layer_idx=layer_idx,
+        )
+
+
+def _validate_qwen3_shapes(
+    moe: Any,
+    *,
+    expected_expert_count: int,
+    layer_idx: int,
+) -> None:
+    switch_mlp = getattr(moe, "switch_mlp", None)
+    if switch_mlp is None:
+        raise ValueError(f"Reloaded layer {layer_idx} does not expose switch_mlp.")
+
+    for projection_name in ("gate_proj", "up_proj", "down_proj"):
+        projection = getattr(switch_mlp, projection_name, None)
+        if projection is None:
+            raise ValueError(
+                f"Reloaded layer {layer_idx} switch_mlp is missing "
+                f"{projection_name}."
+            )
+        _validate_first_dim(
+            getattr(projection, "weight", None),
+            expected_expert_count=expected_expert_count,
+            name=f"layer {layer_idx} switch_mlp.{projection_name}.weight",
+        )
+
+    gate = getattr(moe, "gate", None)
+    if gate is None:
+        raise ValueError(f"Reloaded layer {layer_idx} does not expose a gate.")
+    _validate_first_dim(
+        getattr(gate, "weight", None),
+        expected_expert_count=expected_expert_count,
+        name=f"layer {layer_idx} gate.weight",
+    )
+
+
+def _validate_first_dim(
+    value: Any,
+    *,
+    expected_expert_count: int,
+    name: str,
+) -> None:
+    if value is None:
+        raise ValueError(f"Reloaded {name} is missing.")
+
+    shape = getattr(value, "shape", None)
+    if shape is None or len(shape) < 1:
+        raise ValueError(f"Reloaded {name} must expose a non-empty shape.")
+
+    if int(shape[0]) != expected_expert_count:
+        raise ValueError(
+            f"Reloaded {name} first dimension mismatch: expected "
+            f"{expected_expert_count}, got shape {shape}."
+        )
+
+
+__all__ = [
+    "SaveReloadResult",
+    "generation_smoke",
+    "save_pruned_model",
+]

--- a/tests/test_mlx_save.py
+++ b/tests/test_mlx_save.py
@@ -1,0 +1,373 @@
+"""Tests for MLX save/reload validation helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from reap.backends.mlx.save import (
+    SaveReloadResult,
+    generation_smoke,
+    save_pruned_model,
+)
+
+
+MLX_LM_AVAILABLE = importlib.util.find_spec("mlx_lm") is not None
+
+
+def test_save_module_import_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX save import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        from reap.backends.mlx.save import SaveReloadResult, save_pruned_model
+
+        assert SaveReloadResult is not None
+        assert save_pruned_model is not None
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX save import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+class ConfigTrapModel:
+    @property
+    def config(self):
+        raise AssertionError("save helper must not read model.config")
+
+
+class TinyLinear:
+    def __init__(self, num_experts: int):
+        self.weight = np.zeros((num_experts, 2), dtype=np.float32)
+
+
+class TinySwitchMlp:
+    def __init__(self, num_experts: int):
+        self.gate_proj = TinyLinear(num_experts)
+        self.up_proj = TinyLinear(num_experts)
+        self.down_proj = TinyLinear(num_experts)
+
+
+class TinyGate:
+    def __init__(self, num_experts: int):
+        self.weight = np.zeros((num_experts, 2), dtype=np.float32)
+
+
+class TinyMoe:
+    def __init__(self, num_experts: int, *, weight_experts: int | None = None):
+        self.num_experts = num_experts
+        self.top_k = min(2, num_experts)
+        weight_experts = num_experts if weight_experts is None else weight_experts
+        self.switch_mlp = TinySwitchMlp(weight_experts)
+        self.gate = TinyGate(weight_experts)
+
+
+def make_reloaded_model(num_experts: int, *, weight_experts: int | None = None):
+    moe = TinyMoe(num_experts, weight_experts=weight_experts)
+    return SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(mlp=moe)]),
+    )
+
+
+def write_required_artifacts(output_dir: str | Path):
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    (output_path / "config.json").write_text("{}", encoding="utf-8")
+    (output_path / "model.safetensors").write_bytes(b"weights")
+
+
+def fake_save_factory(calls, *, write_artifacts=True):
+    def fake_save(**kwargs):
+        calls.append(kwargs)
+        if write_artifacts:
+            write_required_artifacts(kwargs["dst_path"])
+
+    return fake_save
+
+
+def fake_load_factory(model, tokenizer, config, calls=None):
+    def fake_load(path, *, return_config=False):
+        if calls is not None:
+            calls.append({"path": path, "return_config": return_config})
+        assert return_config is True
+        return model, tokenizer, config
+
+    return fake_load
+
+
+def test_save_pruned_model_uses_passed_config_and_validates_reload(tmp_path):
+    save_calls = []
+    load_calls = []
+    original_model = ConfigTrapModel()
+    original_tokenizer = object()
+    reloaded_model = make_reloaded_model(2)
+    reloaded_tokenizer = object()
+    config = {"num_experts": 2, "num_experts_per_tok": 2}
+
+    result = save_pruned_model(
+        original_model,
+        original_tokenizer,
+        config,
+        tmp_path / "saved",
+        "source-model",
+        save_fn=fake_save_factory(save_calls),
+        load_fn=fake_load_factory(
+            reloaded_model,
+            reloaded_tokenizer,
+            {"num_experts": 2, "num_experts_per_tok": 2},
+            calls=load_calls,
+        ),
+    )
+
+    assert isinstance(result, SaveReloadResult)
+    assert result.output_dir == tmp_path / "saved"
+    assert result.reloaded_model is reloaded_model
+    assert result.reloaded_tokenizer is reloaded_tokenizer
+    assert result.reloaded_config == {"num_experts": 2, "num_experts_per_tok": 2}
+    assert result.expected_expert_count == 2
+    assert result.smoke_result is None
+
+    assert len(save_calls) == 1
+    assert save_calls[0]["dst_path"] == str(tmp_path / "saved")
+    assert save_calls[0]["src_path_or_repo"] == "source-model"
+    assert save_calls[0]["model"] is original_model
+    assert save_calls[0]["tokenizer"] is original_tokenizer
+    assert save_calls[0]["config"] is config
+    assert load_calls == [
+        {"path": str(tmp_path / "saved"), "return_config": True},
+    ]
+
+
+def test_smoke_function_runs_on_reloaded_model_not_original(tmp_path):
+    smoke_calls = []
+    original_model = object()
+    reloaded_model = make_reloaded_model(1)
+    reloaded_tokenizer = object()
+
+    def smoke_fn(model, tokenizer, config):
+        smoke_calls.append((model, tokenizer, config))
+        return "smoke-ok"
+
+    result = save_pruned_model(
+        original_model,
+        object(),
+        {"num_experts": 1},
+        tmp_path / "saved",
+        "source-model",
+        smoke_fn=smoke_fn,
+        save_fn=fake_save_factory([]),
+        load_fn=fake_load_factory(
+            reloaded_model,
+            reloaded_tokenizer,
+            {"num_experts": 1},
+        ),
+    )
+
+    assert result.smoke_result == "smoke-ok"
+    assert smoke_calls == [(reloaded_model, reloaded_tokenizer, {"num_experts": 1})]
+
+
+def test_save_pruned_model_uses_explicit_expected_count_when_config_missing(tmp_path):
+    result = save_pruned_model(
+        object(),
+        object(),
+        {},
+        tmp_path / "saved",
+        "source-model",
+        expected_expert_count=3,
+        save_fn=fake_save_factory([]),
+        load_fn=fake_load_factory(
+            make_reloaded_model(3),
+            object(),
+            {"num_experts": 3},
+        ),
+    )
+
+    assert result.expected_expert_count == 3
+
+
+@pytest.mark.skipif(
+    MLX_LM_AVAILABLE,
+    reason="mlx_lm is installed, so the lazy missing-dependency path is unavailable.",
+)
+def test_save_pruned_model_requires_lazy_mlx_lm_without_injected_functions(tmp_path):
+    with pytest.raises(ModuleNotFoundError, match="mlx_lm"):
+        save_pruned_model(
+            object(),
+            object(),
+            {"num_experts": 1},
+            tmp_path / "saved",
+            "source-model",
+        )
+
+
+def test_save_pruned_model_rejects_missing_expected_expert_count(tmp_path):
+    with pytest.raises(ValueError, match="expected_expert_count"):
+        save_pruned_model(
+            object(),
+            object(),
+            {},
+            tmp_path / "saved",
+            "source-model",
+            save_fn=fake_save_factory([]),
+            load_fn=fake_load_factory(make_reloaded_model(1), object(), {}),
+        )
+
+
+def test_save_pruned_model_rejects_missing_saved_artifacts(tmp_path):
+    with pytest.raises(RuntimeError, match="missing config.json"):
+        save_pruned_model(
+            object(),
+            object(),
+            {"num_experts": 1},
+            tmp_path / "saved",
+            "source-model",
+            save_fn=fake_save_factory([], write_artifacts=False),
+            load_fn=fake_load_factory(make_reloaded_model(1), object(), {}),
+        )
+
+
+def test_save_pruned_model_rejects_invalid_reload_return(tmp_path):
+    def bad_load(path, *, return_config=False):
+        assert return_config is True
+        return make_reloaded_model(1), object()
+
+    with pytest.raises(ValueError, match="return_config=True"):
+        save_pruned_model(
+            object(),
+            object(),
+            {"num_experts": 1},
+            tmp_path / "saved",
+            "source-model",
+            save_fn=fake_save_factory([]),
+            load_fn=bad_load,
+        )
+
+
+def test_save_pruned_model_rejects_reload_config_mismatch(tmp_path):
+    with pytest.raises(ValueError, match="Reloaded config expert count mismatch"):
+        save_pruned_model(
+            object(),
+            object(),
+            {"num_experts": 2},
+            tmp_path / "saved",
+            "source-model",
+            save_fn=fake_save_factory([]),
+            load_fn=fake_load_factory(
+                make_reloaded_model(2),
+                object(),
+                {"num_experts": 3},
+            ),
+        )
+
+
+def test_save_pruned_model_rejects_reloaded_shape_mismatch(tmp_path):
+    with pytest.raises(ValueError, match="first dimension mismatch"):
+        save_pruned_model(
+            object(),
+            object(),
+            {"num_experts": 2},
+            tmp_path / "saved",
+            "source-model",
+            save_fn=fake_save_factory([]),
+            load_fn=fake_load_factory(
+                make_reloaded_model(2, weight_experts=3),
+                object(),
+                {"num_experts": 2},
+            ),
+        )
+
+
+def test_save_pruned_model_rejects_output_path_that_is_file(tmp_path):
+    output_file = tmp_path / "saved"
+    output_file.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(OSError, match="not a directory"):
+        save_pruned_model(
+            object(),
+            object(),
+            {"num_experts": 1},
+            output_file,
+            "source-model",
+            save_fn=fake_save_factory([]),
+            load_fn=fake_load_factory(make_reloaded_model(1), object(), {}),
+        )
+
+
+def test_generation_smoke_formats_chat_prompt_and_calls_generate():
+    calls = []
+
+    class Tokenizer:
+        chat_template = "template"
+
+        def apply_chat_template(self, messages, *, add_generation_prompt):
+            assert messages == [{"role": "user", "content": "Who are you?"}]
+            assert add_generation_prompt is True
+            return "<chat>Who are you?</chat>"
+
+    def generate_fn(model, tokenizer, *, prompt, max_tokens):
+        calls.append((model, tokenizer, prompt, max_tokens))
+        return "hello"
+
+    model = object()
+    tokenizer = Tokenizer()
+
+    result = generation_smoke(
+        model,
+        tokenizer,
+        prompt="Who are you?",
+        max_tokens=4,
+        generate_fn=generate_fn,
+    )
+
+    assert result == "hello"
+    assert calls == [(model, tokenizer, "<chat>Who are you?</chat>", 4)]


### PR DESCRIPTION
## Summary
- add import-safe MLX save/reload validation helpers for pruned models
- save with the updated config dict, reload from disk, and validate reloaded expert counts/shapes
- add mock-based tests for save/load wiring, artifact checks, smoke hooks, and error handling

Closes #7

## Tests
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py tests/test_mlx_model_adapters.py tests/test_mlx_observer.py tests/test_mlx_prune.py tests/test_mlx_save.py
- PYTHONPATH=src .venv/bin/python -m py_compile src/reap/backends/mlx/save.py tests/test_mlx_save.py
- git diff --check HEAD~1..HEAD