### PR TITLE
Add MLX calibration CLI pipeline

### DIFF
--- a/experiments/mlx-pruning.sh
+++ b/experiments/mlx-pruning.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# MLX REAP pruning experiment wrapper.
+# Usage: bash experiments/mlx-pruning.sh [MODEL_NAME] [DATASET] [PRUNE_METHOD] [COMPRESSION_RATIO] [SEED]
+
+MODEL=${1:-"mlx-community/Qwen3-30B-A3B-4bit-DWQ"}
+DATASET=${2:-"theblackcat102/evol-codealpaca-v1"}
+METHOD=${3:-"reap"}
+RATIO=${4:-"0.25"}
+SEED=${5:-"42"}
+MAX_SAMPLES=${MAX_SAMPLES:-8}
+MAX_SEQ_LENGTH=${MAX_SEQ_LENGTH:-1024}
+OUTPUT_DIR=${OUTPUT_DIR:-"artifacts/mlx/$(basename "$MODEL")/${METHOD}-${RATIO}-seed-${SEED}"}
+
+echo "=== REAP MLX Pruning ==="
+echo "Model:          $MODEL"
+echo "Dataset:        $DATASET"
+echo "Method:         $METHOD"
+echo "Ratio:          $RATIO"
+echo "Seed:           $SEED"
+echo "Max samples:    $MAX_SAMPLES"
+echo "Max seq length: $MAX_SEQ_LENGTH"
+echo "Output:         $OUTPUT_DIR"
+
+python -m reap.backends.mlx.entrypoint \
+    --model-name "$MODEL" \
+    --dataset-name "$DATASET" \
+    --prune-method "$METHOD" \
+    --compression-ratio "$RATIO" \
+    --seed "$SEED" \
+    --max-samples "$MAX_SAMPLES" \
+    --max-seq-length "$MAX_SEQ_LENGTH" \
+    --output-dir "$OUTPUT_DIR" \
+    --verbose

--- a/src/reap/backends/mlx/data.py
+++ b/src/reap/backends/mlx/data.py
@@ -1,0 +1,246 @@
+"""Minimal calibration loading for the MLX pruning pipeline.
+
+This module stays independent of the existing Torch/vLLM data pipeline. The
+dataset dependency is imported lazily only when calibration data is loaded.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+
+def load_calibration_sequences(
+    tokenizer: Any,
+    dataset_name: str,
+    *,
+    split: str = "train",
+    dataset_config_name: str | None = None,
+    max_samples: int = 128,
+    max_seq_length: int = 2048,
+    seed: int = 42,
+    load_dataset_fn: Callable[..., Iterable[Any]] | None = None,
+) -> list[dict[str, np.ndarray]]:
+    """Load unpadded batch-size-1 calibration token sequences."""
+    max_samples = _positive_int(max_samples, "max_samples")
+    max_seq_length = _positive_int(max_seq_length, "max_seq_length")
+    load_dataset_fn = _default_load_dataset if load_dataset_fn is None else load_dataset_fn
+
+    load_kwargs: dict[str, Any] = {"split": split}
+    if dataset_config_name is not None:
+        load_kwargs["name"] = dataset_config_name
+    dataset = load_dataset_fn(dataset_name, **load_kwargs)
+    dataset = _maybe_shuffle(dataset, seed)
+
+    sequences: list[dict[str, np.ndarray]] = []
+    for record in dataset:
+        text = extract_text(record, tokenizer=tokenizer)
+        token_ids = tokenize_text(
+            tokenizer,
+            text,
+            max_seq_length=max_seq_length,
+        )
+        if not token_ids:
+            continue
+
+        sequences.append(
+            {
+                "input_ids": np.asarray(token_ids, dtype=np.int32),
+            }
+        )
+        if len(sequences) >= max_samples:
+            break
+
+    return sequences
+
+
+def extract_text(record: Any, *, tokenizer: Any | None = None) -> str:
+    """Extract text from common calibration dataset record shapes."""
+    if not isinstance(record, Mapping):
+        return _normalize_content(record).strip()
+
+    for field_name in ("messages", "conversations"):
+        messages = _maybe_json_load(record.get(field_name))
+        if messages:
+            return _messages_to_text(messages, tokenizer=tokenizer).strip()
+
+    text = record.get("text")
+    if text is not None:
+        return _normalize_content(text).strip()
+
+    instruction = _first_present(record, "instruction", "prompt", "question")
+    output = _first_present(record, "output", "completion", "response", "answer")
+    input_text = _first_present(record, "input", "context")
+    if instruction is not None or output is not None:
+        parts = [
+            _normalize_content(part).strip()
+            for part in (instruction, input_text, output)
+            if part is not None
+        ]
+        return "\n\n".join(part for part in parts if part)
+
+    return ""
+
+
+def tokenize_text(
+    tokenizer: Any,
+    text: str,
+    *,
+    max_seq_length: int,
+) -> list[int]:
+    """Tokenize text and truncate to ``max_seq_length`` tokens."""
+    max_seq_length = _positive_int(max_seq_length, "max_seq_length")
+    text = text.strip()
+    if not text:
+        return []
+
+    encode = getattr(tokenizer, "encode", None)
+    if callable(encode):
+        try:
+            token_ids = encode(text, add_special_tokens=True)
+        except TypeError:
+            token_ids = encode(text)
+    elif callable(tokenizer):
+        encoded = tokenizer(text)
+        token_ids = _input_ids_from_encoded(encoded)
+    else:
+        raise TypeError("tokenizer must expose encode(...) or be callable.")
+
+    token_ids = _flatten_token_ids(token_ids)
+    return [int(token_id) for token_id in token_ids[:max_seq_length]]
+
+
+def _default_load_dataset(*args: Any, **kwargs: Any) -> Iterable[Any]:
+    try:
+        from datasets import load_dataset
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "load_calibration_sequences requires the optional 'datasets' package "
+            "when load_dataset_fn is not provided."
+        ) from exc
+    return load_dataset(*args, **kwargs)
+
+
+def _positive_int(value: Any, name: str) -> int:
+    try:
+        value = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer.") from exc
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer, got {value}.")
+    return value
+
+
+def _maybe_shuffle(dataset: Iterable[Any], seed: int) -> Iterable[Any]:
+    shuffle = getattr(dataset, "shuffle", None)
+    if callable(shuffle):
+        return shuffle(seed=seed)
+
+    return dataset
+
+
+def _maybe_json_load(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _messages_to_text(messages: Any, *, tokenizer: Any | None) -> str:
+    if not isinstance(messages, list):
+        return _normalize_content(messages)
+
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if callable(apply_chat_template):
+        try:
+            rendered = apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=False,
+            )
+        except TypeError:
+            rendered = apply_chat_template(messages, tokenize=False)
+        return _normalize_content(rendered)
+
+    parts = []
+    for message in messages:
+        if not isinstance(message, Mapping):
+            content = _normalize_content(message).strip()
+            if content:
+                parts.append(content)
+            continue
+
+        role = _first_present(message, "role", "from", "speaker")
+        content = _first_present(message, "content", "value", "text")
+        content_text = _normalize_content(content).strip()
+        if not content_text:
+            continue
+        role_text = _normalize_content(role).strip()
+        if role_text:
+            parts.append(f"{role_text}: {content_text}")
+        else:
+            parts.append(content_text)
+    return "\n".join(parts)
+
+
+def _normalize_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, Mapping):
+                if item.get("type") == "text" and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                else:
+                    parts.append(json.dumps(dict(item), sort_keys=True))
+            else:
+                parts.append(_normalize_content(item))
+        return "\n".join(part for part in parts if part)
+    if isinstance(content, Mapping):
+        return json.dumps(dict(content), sort_keys=True)
+    return str(content)
+
+
+def _first_present(record: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = record.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _input_ids_from_encoded(encoded: Any) -> Any:
+    if isinstance(encoded, Mapping):
+        return encoded["input_ids"]
+    input_ids = getattr(encoded, "input_ids", None)
+    if input_ids is not None:
+        return input_ids
+    raise TypeError("Callable tokenizer output must expose input_ids.")
+
+
+def _flatten_token_ids(token_ids: Any) -> list[Any]:
+    if hasattr(token_ids, "tolist"):
+        token_ids = token_ids.tolist()
+    if (
+        isinstance(token_ids, Sequence)
+        and token_ids
+        and isinstance(token_ids[0], Sequence)
+        and not isinstance(token_ids[0], (str, bytes))
+    ):
+        token_ids = token_ids[0]
+    return list(token_ids)
+
+
+__all__ = [
+    "extract_text",
+    "load_calibration_sequences",
+    "tokenize_text",
+]

--- a/src/reap/backends/mlx/entrypoint.py
+++ b/src/reap/backends/mlx/entrypoint.py
@@ -1,0 +1,178 @@
+"""Command-line entrypoint for MLX REAP expert pruning."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from reap.backends.mlx.data import load_calibration_sequences
+from reap.backends.mlx.observer import observe_model
+from reap.backends.mlx.prune import prune_experts, resolve_prune_method
+from reap.backends.mlx.save import generation_smoke, save_pruned_model
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the MLX pruning CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Run the MLX-only REAP expert pruning pipeline.",
+    )
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--dataset-config-name")
+    parser.add_argument("--prune-method", default="reap")
+    parser.add_argument("--compression-ratio", type=float, default=0.25)
+    parser.add_argument(
+        "--max-samples",
+        "--num-calibration-sequences",
+        dest="max_samples",
+        type=int,
+        default=128,
+    )
+    parser.add_argument("--max-seq-length", type=int, default=2048)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--no-smoke",
+        action="store_true",
+        help="Skip generation smoke after save/reload validation.",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    load_model_fn: Callable[[str], tuple[Any, Any, Mapping[str, Any]]] | None = None,
+    load_calibration_sequences_fn: Callable[..., list[Any]] | None = None,
+    observe_model_fn: Callable[..., dict[int, dict[str, Any]]] | None = None,
+    prune_experts_fn: Callable[..., dict[int, Any]] | None = None,
+    save_pruned_model_fn: Callable[..., Any] | None = None,
+    smoke_fn: Callable[[Any, Any, Mapping[str, Any]], Any] | None = None,
+    print_fn: Callable[[str], Any] = print,
+) -> int:
+    """Run the MLX pruning pipeline and return a process exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        _validate_args(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING)
+
+    load_model_fn = _default_load_model if load_model_fn is None else load_model_fn
+    load_calibration_sequences_fn = (
+        load_calibration_sequences
+        if load_calibration_sequences_fn is None
+        else load_calibration_sequences_fn
+    )
+    observe_model_fn = observe_model if observe_model_fn is None else observe_model_fn
+    prune_experts_fn = prune_experts if prune_experts_fn is None else prune_experts_fn
+    save_pruned_model_fn = (
+        save_pruned_model if save_pruned_model_fn is None else save_pruned_model_fn
+    )
+    smoke_fn = generation_smoke if smoke_fn is None and not args.no_smoke else smoke_fn
+    if args.no_smoke:
+        smoke_fn = None
+
+    try:
+        _emit(print_fn, "load: loading MLX-LM model")
+        model, tokenizer, config = load_model_fn(args.model_name)
+        if not isinstance(config, Mapping):
+            raise ValueError("MLX-LM load must return a mapping config.")
+
+        _emit(print_fn, "calibrate: loading calibration sequences")
+        calibration_sequences = load_calibration_sequences_fn(
+            tokenizer,
+            args.dataset_name,
+            split=args.split,
+            dataset_config_name=args.dataset_config_name,
+            max_samples=args.max_samples,
+            max_seq_length=args.max_seq_length,
+            seed=args.seed,
+        )
+        if not calibration_sequences:
+            raise RuntimeError("No non-empty calibration sequences were loaded.")
+
+        _emit(print_fn, "observe: collecting pruning metrics")
+        observer_data = observe_model_fn(
+            model,
+            calibration_sequences,
+            config,
+        )
+
+        _emit(print_fn, "prune: mutating selected experts")
+        prune_experts_fn(
+            model,
+            config,
+            observer_data,
+            args.prune_method,
+            args.compression_ratio,
+        )
+
+        _emit(print_fn, "save: saving pruned model and validating reload")
+        result = save_pruned_model_fn(
+            model,
+            tokenizer,
+            config,
+            args.output_dir,
+            args.model_name,
+            smoke_fn=smoke_fn,
+        )
+        _emit(print_fn, "reload/smoke: validation complete")
+        _emit(print_fn, f"done: saved MLX pruned model to {result.output_dir}")
+        return 0
+    except KeyboardInterrupt:
+        _emit(print_fn, "interrupted: MLX pruning stopped")
+        return 130
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    resolve_prune_method(args.prune_method)
+    _validate_positive_int(args.max_samples, "max_samples")
+    _validate_positive_int(args.max_seq_length, "max_seq_length")
+
+    ratio = float(args.compression_ratio)
+    if not math.isfinite(ratio) or ratio < 0.0 or ratio >= 1.0:
+        raise ValueError(f"compression_ratio must be in [0, 1), got {ratio}.")
+
+
+def _validate_positive_int(value: Any, name: str) -> None:
+    if int(value) < 1:
+        raise ValueError(f"{name} must be a positive integer, got {value}.")
+
+
+def _default_load_model(model_name: str) -> tuple[Any, Any, Mapping[str, Any]]:
+    try:
+        from mlx_lm import load
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "MLX entrypoint requires the optional 'mlx_lm' package to load models."
+        ) from exc
+
+    loaded = load(model_name, return_config=True)
+    if not isinstance(loaded, tuple) or len(loaded) != 3:
+        raise ValueError(
+            "Expected mlx_lm.load(..., return_config=True) to return "
+            "(model, tokenizer, config)."
+        )
+    return loaded
+
+
+def _emit(print_fn: Callable[[str], Any], message: str) -> None:
+    print_fn(f"[reap-mlx] {message}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["build_parser", "main"]

--- a/tests/test_mlx_cli.py
+++ b/tests/test_mlx_cli.py
@@ -1,0 +1,285 @@
+"""Tests for the MLX pruning CLI entrypoint."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reap.backends.mlx.entrypoint import main
+
+
+def _subprocess_with_import_blocker(body: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        f"""
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm", "datasets")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX CLI import/run: "
+                        f"{{fullname}}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        {body}
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_entrypoint_import_does_not_import_heavy_runtime_packages():
+    result = _subprocess_with_import_blocker(
+        """
+        from reap.backends.mlx.entrypoint import build_parser, main
+
+        assert build_parser is not None
+        assert main is not None
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX CLI import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_help_works_without_heavy_runtime_imports():
+    result = _subprocess_with_import_blocker(
+        """
+        from reap.backends.mlx.entrypoint import main
+
+        raise SystemExit(main(["--help"]))
+        """
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "--model-name" in result.stdout
+    assert "--dataset-name" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "message"),
+    [
+        (["--compression-ratio", "1.0"], "compression_ratio"),
+        (["--compression-ratio", "-0.1"], "compression_ratio"),
+        (["--compression-ratio", "nan"], "compression_ratio"),
+        (["--prune-method", "ean_ca"], "Unsupported prune method"),
+        (["--max-samples", "0"], "max_samples"),
+        (["--max-seq-length", "0"], "max_seq_length"),
+    ],
+)
+def test_invalid_arguments_fail_before_pipeline_functions(extra_args, message):
+    def fail_load_model(model_name):
+        raise AssertionError("load_model_fn must not be called for invalid args")
+
+    args = [
+        "--model-name",
+        "model",
+        "--dataset-name",
+        "dataset",
+        "--output-dir",
+        "out",
+        *extra_args,
+    ]
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(args, load_model_fn=fail_load_model)
+
+    assert exc_info.value.code == 2
+
+
+def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_path):
+    events = []
+    output = []
+    model = object()
+    tokenizer = object()
+    config = {"num_experts": 4, "num_experts_per_tok": 2}
+    smoke = object()
+
+    def fake_load_model(model_name):
+        events.append(("load", model_name))
+        return model, tokenizer, config
+
+    def fake_load_calibration_sequences(tokenizer_arg, dataset_name, **kwargs):
+        events.append(("calibrate", tokenizer_arg, dataset_name, kwargs))
+        return [{"input_ids": [1, 2, 3]}]
+
+    def fake_observe_model(model_arg, sequences, config_arg):
+        events.append(("observe", model_arg, sequences, config_arg))
+        return {0: {"reap": [1.0, 0.5, 0.25, 0.0]}}
+
+    def fake_prune_experts(model_arg, config_arg, observer_data, method, ratio):
+        events.append(("prune", model_arg, config_arg, observer_data, method, ratio))
+        config_arg["num_experts"] = 3
+        return {0: [0, 1, 2]}
+
+    def fake_save_pruned_model(
+        model_arg,
+        tokenizer_arg,
+        config_arg,
+        output_dir,
+        original_model_name,
+        **kwargs,
+    ):
+        events.append(
+            (
+                "save",
+                model_arg,
+                tokenizer_arg,
+                config_arg,
+                output_dir,
+                original_model_name,
+                kwargs,
+            )
+        )
+        return SimpleNamespace(output_dir=Path(output_dir))
+
+    code = main(
+        [
+            "--model-name",
+            "mlx-model",
+            "--dataset-name",
+            "calibration-data",
+            "--split",
+            "validation",
+            "--dataset-config-name",
+            "code",
+            "--prune-method",
+            "frequency",
+            "--compression-ratio",
+            "0.25",
+            "--num-calibration-sequences",
+            "3",
+            "--max-seq-length",
+            "16",
+            "--seed",
+            "9",
+            "--output-dir",
+            str(tmp_path / "pruned"),
+        ],
+        load_model_fn=fake_load_model,
+        load_calibration_sequences_fn=fake_load_calibration_sequences,
+        observe_model_fn=fake_observe_model,
+        prune_experts_fn=fake_prune_experts,
+        save_pruned_model_fn=fake_save_pruned_model,
+        smoke_fn=smoke,
+        print_fn=output.append,
+    )
+
+    assert code == 0
+    assert [event[0] for event in events] == [
+        "load",
+        "calibrate",
+        "observe",
+        "prune",
+        "save",
+    ]
+    assert events[0] == ("load", "mlx-model")
+    assert events[1][1] is tokenizer
+    assert events[1][2] == "calibration-data"
+    assert events[1][3] == {
+        "split": "validation",
+        "dataset_config_name": "code",
+        "max_samples": 3,
+        "max_seq_length": 16,
+        "seed": 9,
+    }
+    assert events[3][4:] == ("frequency", 0.25)
+    assert events[4][6]["smoke_fn"] is smoke
+    assert any("load:" in line for line in output)
+    assert any("calibrate:" in line for line in output)
+    assert any("observe:" in line for line in output)
+    assert any("prune:" in line for line in output)
+    assert any("save:" in line for line in output)
+    assert any("reload/smoke:" in line for line in output)
+    assert any("done:" in line for line in output)
+
+
+def test_no_smoke_passes_no_smoke_function_to_save(tmp_path):
+    save_kwargs = {}
+
+    def fake_save_pruned_model(*args, **kwargs):
+        del args
+        save_kwargs.update(kwargs)
+        return SimpleNamespace(output_dir=tmp_path)
+
+    code = main(
+        [
+            "--model-name",
+            "model",
+            "--dataset-name",
+            "dataset",
+            "--output-dir",
+            str(tmp_path),
+            "--no-smoke",
+        ],
+        load_model_fn=lambda model_name: (object(), object(), {"num_experts": 1}),
+        load_calibration_sequences_fn=lambda *args, **kwargs: [{"input_ids": [1]}],
+        observe_model_fn=lambda *args, **kwargs: {0: {"reap": [1.0]}},
+        prune_experts_fn=lambda *args, **kwargs: {},
+        save_pruned_model_fn=fake_save_pruned_model,
+        smoke_fn=object(),
+        print_fn=lambda message: None,
+    )
+
+    assert code == 0
+    assert save_kwargs["smoke_fn"] is None
+
+
+def test_keyboard_interrupt_returns_130_without_success_message():
+    output = []
+
+    def interrupt(model_name):
+        del model_name
+        raise KeyboardInterrupt
+
+    code = main(
+        [
+            "--model-name",
+            "model",
+            "--dataset-name",
+            "dataset",
+            "--output-dir",
+            "out",
+        ],
+        load_model_fn=interrupt,
+        print_fn=output.append,
+    )
+
+    assert code == 130
+    assert any("interrupted:" in line for line in output)
+    assert not any("done:" in line for line in output)

--- a/tests/test_mlx_data.py
+++ b/tests/test_mlx_data.py
@@ -1,0 +1,251 @@
+"""Tests for the MLX calibration data loader."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+
+from reap.backends.mlx.data import (
+    extract_text,
+    load_calibration_sequences,
+    tokenize_text,
+)
+
+
+def test_data_module_import_does_not_import_heavy_runtime_packages():
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm", "datasets")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX data import: "
+                        f"{fullname}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        from reap.backends.mlx.data import load_calibration_sequences
+
+        assert load_calibration_sequences is not None
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX data import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+class WhitespaceTokenizer:
+    chat_template = None
+
+    def __init__(self):
+        self.texts = []
+
+    def encode(self, text, add_special_tokens=True):
+        del add_special_tokens
+        self.texts.append(text)
+        return [len(piece) for piece in text.split()]
+
+
+class ChatTokenizer(WhitespaceTokenizer):
+    chat_template = "template"
+
+    def __init__(self):
+        super().__init__()
+        self.template_calls = []
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize=False,
+        add_generation_prompt=False,
+    ):
+        self.template_calls.append(
+            {
+                "messages": messages,
+                "tokenize": tokenize,
+                "add_generation_prompt": add_generation_prompt,
+            }
+        )
+        return " ".join(f"{message['role']}:{message['content']}" for message in messages)
+
+
+class CallableTokenizer:
+    def __call__(self, text):
+        return {"input_ids": [[ord(char) for char in text]]}
+
+
+def test_load_calibration_sequences_forwards_dataset_options_and_truncates():
+    calls = []
+
+    def fake_load_dataset(dataset_name, **kwargs):
+        calls.append((dataset_name, kwargs))
+        return [
+            {"text": "alpha beta gamma"},
+            {"text": "   "},
+            {"text": "delta epsilon"},
+        ]
+
+    tokenizer = WhitespaceTokenizer()
+
+    sequences = load_calibration_sequences(
+        tokenizer,
+        "example/dataset",
+        split="validation",
+        dataset_config_name="code",
+        max_samples=2,
+        max_seq_length=2,
+        seed=123,
+        load_dataset_fn=fake_load_dataset,
+    )
+
+    assert calls == [
+        (
+            "example/dataset",
+            {"split": "validation", "name": "code"},
+        )
+    ]
+    assert len(sequences) == 2
+    assert sequences[0]["input_ids"].dtype == np.int32
+    np.testing.assert_array_equal(sequences[0]["input_ids"], [5, 4])
+    np.testing.assert_array_equal(sequences[1]["input_ids"], [5, 7])
+
+
+def test_extract_text_supports_instruction_input_output_records():
+    text = extract_text(
+        {
+            "instruction": "Write a function.",
+            "input": "Use Python.",
+            "output": "def f(): pass",
+        }
+    )
+
+    assert text == "Write a function.\n\nUse Python.\n\ndef f(): pass"
+
+
+def test_message_records_use_tokenizer_chat_template_when_available():
+    tokenizer = ChatTokenizer()
+
+    sequences = load_calibration_sequences(
+        tokenizer,
+        "chat/data",
+        max_samples=1,
+        max_seq_length=10,
+        load_dataset_fn=lambda dataset_name, **kwargs: [
+            {
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"},
+                ]
+            }
+        ],
+    )
+
+    assert tokenizer.template_calls == [
+        {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ],
+            "tokenize": False,
+            "add_generation_prompt": False,
+        }
+    ]
+    assert tokenizer.texts == ["user:Hello assistant:Hi"]
+    np.testing.assert_array_equal(sequences[0]["input_ids"], [10, 12])
+
+
+def test_conversation_records_fall_back_to_role_content_text():
+    text = extract_text(
+        {
+            "conversations": [
+                {"from": "human", "value": "Explain REAP."},
+                {"from": "assistant", "value": "REAP prunes experts."},
+            ]
+        },
+        tokenizer=WhitespaceTokenizer(),
+    )
+
+    assert text == "human: Explain REAP.\nassistant: REAP prunes experts."
+
+
+class RecordingShuffleDataset(list):
+    def __init__(self, records):
+        super().__init__(records)
+        self.seeds = []
+
+    def shuffle(self, *, seed):
+        self.seeds.append(seed)
+        records = list(self)
+        records.reverse()
+        return records
+
+
+def test_dataset_shuffle_is_used_with_seed_before_sampling():
+    dataset = RecordingShuffleDataset(
+        [
+            {"text": "one"},
+            {"text": "two"},
+            {"text": "three"},
+        ]
+    )
+
+    sequences = load_calibration_sequences(
+        WhitespaceTokenizer(),
+        "shuffle/data",
+        max_samples=1,
+        max_seq_length=10,
+        seed=7,
+        load_dataset_fn=lambda dataset_name, **kwargs: dataset,
+    )
+
+    assert dataset.seeds == [7]
+    np.testing.assert_array_equal(sequences[0]["input_ids"], [5])
+
+
+def test_callable_tokenizer_outputs_are_supported_and_flattened():
+    token_ids = tokenize_text(
+        CallableTokenizer(),
+        "ab",
+        max_seq_length=1,
+    )
+
+    assert token_ids == [97]


### PR DESCRIPTION
## Summary
- add an MLX-only calibration loader for unpadded single-sequence samples
- add an import-safe MLX pruning CLI that wires load, calibrate, observe, prune, save, and smoke validation
- add an experiment wrapper and focused data/CLI tests

Closes #8

## Tests
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py tests/test_mlx_model_adapters.py tests/test_mlx_observer.py tests/test_mlx_prune.py tests/test_mlx_save.py tests/test_mlx_data.py tests/test_mlx_cli.py
- PYTHONPATH=src .venv/bin/python -m reap.backends.mlx.entrypoint --help
- bash -n experiments/mlx-pruning.sh
- git diff --check