### PR TITLE
Add MLX LFM2 MoE adapter

### DIFF
--- a/src/reap/backends/mlx/model_adapters.py
+++ b/src/reap/backends/mlx/model_adapters.py
@@ -19,6 +19,7 @@ class MoeLayerConfig:
     top_k: int
     norm_topk_prob: bool
     adapter_name: str = "qwen3_moe"
+    use_expert_bias: bool = False
 
 
 def _lookup_attr_path(root: Any, path: tuple[str, ...]) -> Any | None:
@@ -119,6 +120,16 @@ def update_qwen3_moe_config(
     return config
 
 
+def update_lfm2_moe_config(
+    config: MutableMapping[str, Any],
+    *,
+    num_experts: int,
+    top_k: int,
+) -> MutableMapping[str, Any]:
+    """Update an LFM2 MoE config dict after expert pruning."""
+    return update_qwen3_moe_config(config, num_experts=num_experts, top_k=top_k)
+
+
 def make_attention_mask(hidden_states: Any, cache: Any | None = None) -> Any:
     """Build an MLX-LM causal attention mask using the installed MLX-LM helper."""
     try:
@@ -130,6 +141,19 @@ def make_attention_mask(hidden_states: Any, cache: Any | None = None) -> Any:
         ) from exc
 
     return create_attention_mask(hidden_states, cache=cache)
+
+
+def make_ssm_mask(hidden_states: Any, cache: Any | None = None) -> Any:
+    """Build an MLX-LM SSM/conv mask using the installed MLX-LM helper."""
+    try:
+        from mlx_lm.models.base import create_ssm_mask
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "make_ssm_mask requires the optional 'mlx_lm' package. "
+            "Install MLX-LM before constructing MLX SSM masks."
+        ) from exc
+
+    return create_ssm_mask(hidden_states, cache=cache)
 
 
 class Qwen3MoeModelAdapter:
@@ -205,11 +229,130 @@ class Qwen3MoeModelAdapter:
         )
 
 
+class Lfm2MoeModelAdapter:
+    """Liquid LFM2.5 MoE adapter for MLX-LM-style model objects."""
+
+    adapter_name = "lfm2_moe"
+
+    def layers(self, model: Any) -> Sequence[Any]:
+        return get_model_layers(model)
+
+    def identify_moe_layers(self, model: Any) -> list[int]:
+        return [
+            layer_idx
+            for layer_idx, layer in enumerate(self.layers(model))
+            if self.is_moe_layer(layer)
+        ]
+
+    def is_moe_layer(self, layer: Any) -> bool:
+        feed_forward = getattr(layer, "feed_forward", None)
+        return (
+            feed_forward is not None
+            and getattr(feed_forward, "switch_mlp", None) is not None
+        )
+
+    def get_moe(self, layer: Any) -> Any:
+        if not self.is_moe_layer(layer):
+            raise ValueError(
+                "Layer does not expose an LFM2-style MoE feed_forward.switch_mlp."
+            )
+        return layer.feed_forward
+
+    def get_dense_mlp(self, layer: Any) -> Any:
+        feed_forward = getattr(layer, "feed_forward", None)
+        if feed_forward is None:
+            raise ValueError("Layer does not expose a feed_forward module.")
+        return feed_forward
+
+    def get_layer_config(
+        self,
+        layer: Any,
+        config: Mapping[str, Any] | None = None,
+    ) -> MoeLayerConfig:
+        moe = self.get_moe(layer)
+
+        num_experts = _positive_int(
+            _live_or_config_value(
+                moe,
+                ("num_experts",),
+                config,
+                ("num_experts",),
+            ),
+            "num_experts",
+        )
+        top_k = _positive_int(
+            _live_or_config_value(
+                moe,
+                ("top_k", "num_experts_per_tok"),
+                config,
+                ("num_experts_per_tok", "top_k"),
+            ),
+            "top_k",
+        )
+        norm_topk_prob = bool(
+            _live_or_config_value(
+                moe,
+                ("norm_topk_prob",),
+                config,
+                ("norm_topk_prob",),
+                default=False,
+            )
+        )
+        use_expert_bias = bool(
+            _live_or_config_value(
+                moe,
+                ("use_expert_bias",),
+                config,
+                ("use_expert_bias",),
+                default=False,
+            )
+        )
+
+        return MoeLayerConfig(
+            num_experts=num_experts,
+            top_k=top_k,
+            norm_topk_prob=norm_topk_prob,
+            adapter_name=self.adapter_name,
+            use_expert_bias=use_expert_bias,
+        )
+
+
+def infer_model_adapter(
+    model: Any | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> Any:
+    """Infer the MLX architecture adapter from config or model layout."""
+    model_type = _config_value(config, "model_type")
+    architectures = _config_value(config, "architectures", default=()) or ()
+    if model_type == "lfm2_moe" or any(
+        str(architecture).startswith("Lfm2") for architecture in architectures
+    ):
+        return Lfm2MoeModelAdapter()
+
+    if model is not None:
+        try:
+            layers = get_model_layers(model)
+        except ValueError:
+            layers = ()
+        if any(
+            getattr(getattr(layer, "feed_forward", None), "switch_mlp", None)
+            is not None
+            for layer in layers
+        ):
+            return Lfm2MoeModelAdapter()
+
+    return Qwen3MoeModelAdapter()
+
+
 __all__ = [
+    "Lfm2MoeModelAdapter",
     "MoeLayerConfig",
     "Qwen3MoeModelAdapter",
     "get_model_layers",
     "get_shared_expert",
+    "infer_model_adapter",
     "make_attention_mask",
+    "make_ssm_mask",
+    "update_lfm2_moe_config",
     "update_qwen3_moe_config",
 ]

--- a/src/reap/backends/mlx/observer.py
+++ b/src/reap/backends/mlx/observer.py
@@ -13,11 +13,12 @@ from typing import Any, Callable
 
 from reap.backends.mlx.metrics import PruningState
 from reap.backends.mlx.model_adapters import (
-    Qwen3MoeModelAdapter,
     get_shared_expert,
+    infer_model_adapter,
     make_attention_mask,
+    make_ssm_mask,
 )
-from reap.backends.mlx.router import Qwen3MoeRouter
+from reap.backends.mlx.router import Lfm2MoeRouter, Qwen3MoeRouter
 
 
 logger = logging.getLogger(__name__)
@@ -35,10 +36,43 @@ def observe_model(
 ) -> dict[int, dict[str, Any]]:
     """Collect pruning-compatible observer data with explicit MLX layer replay."""
     mx = _require_mlx_core()
-    adapter = Qwen3MoeModelAdapter() if adapter is None else adapter
     config = {} if config is None else config
+    adapter = infer_model_adapter(model, config) if adapter is None else adapter
     eval_fn = mx.eval if eval_fn is None else eval_fn
 
+    if getattr(adapter, "adapter_name", None) == "lfm2_moe":
+        return _observe_lfm2_model(
+            model,
+            calibration_sequences,
+            config,
+            adapter=adapter,
+            debug_memory=debug_memory,
+            eval_fn=eval_fn,
+            mask_fn=mask_fn,
+        )
+
+    return _observe_qwen3_model(
+        model,
+        calibration_sequences,
+        config,
+        adapter=adapter,
+        debug_memory=debug_memory,
+        eval_fn=eval_fn,
+        mask_fn=mask_fn,
+    )
+
+
+def _observe_qwen3_model(
+    model: Any,
+    calibration_sequences: list[Any],
+    config: Mapping[str, Any],
+    *,
+    adapter: Any,
+    debug_memory: bool,
+    eval_fn: Callable[[Any], Any],
+    mask_fn: Callable[..., Any] | None,
+) -> dict[int, dict[str, Any]]:
+    mx = _require_mlx_core()
     layers = adapter.layers(model)
     moe_layer_indices = set(adapter.identify_moe_layers(model))
     embed_tokens = _get_embed_tokens(model)
@@ -74,6 +108,61 @@ def observe_model(
             else:
                 dense_mlp = adapter.get_dense_mlp(layer)
                 h = h + dense_mlp(moe_input)
+
+            eval_fn(h)
+            if debug_memory:
+                _log_memory(mx, layer_idx)
+
+    return {layer_idx: state.report() for layer_idx, state in accumulators.items()}
+
+
+def _observe_lfm2_model(
+    model: Any,
+    calibration_sequences: list[Any],
+    config: Mapping[str, Any],
+    *,
+    adapter: Any,
+    debug_memory: bool,
+    eval_fn: Callable[[Any], Any],
+    mask_fn: Callable[..., Any] | None,
+) -> dict[int, dict[str, Any]]:
+    mx = _require_mlx_core()
+    layers = adapter.layers(model)
+    moe_layer_indices = set(adapter.identify_moe_layers(model))
+    embed_tokens = _get_embed_tokens(model)
+
+    accumulators = _initialize_accumulators(
+        layers,
+        moe_layer_indices,
+        adapter=adapter,
+        config=config,
+    )
+
+    for sequence in calibration_sequences:
+        tokens = _batch_tokens(mx, sequence)
+        h = embed_tokens(tokens)
+        attn_mask, conv_mask = _lfm2_masks(
+            h,
+            sequence_length=tokens.shape[-1],
+            mask_fn=mask_fn,
+        )
+
+        for layer_idx, layer in enumerate(layers):
+            operator_mask = attn_mask if _is_lfm2_attention_layer(layer) else conv_mask
+            h_mid = _run_lfm2_operator(layer, h, operator_mask)
+            ffn_input = _call_required(layer, "ffn_norm", h_mid)
+
+            if layer_idx in moe_layer_indices:
+                h = h_mid + _observe_lfm2_moe_layer(
+                    layer,
+                    ffn_input,
+                    accumulators[layer_idx],
+                    adapter=adapter,
+                    config=config,
+                )
+            else:
+                dense_mlp = adapter.get_dense_mlp(layer)
+                h = h_mid + dense_mlp(ffn_input)
 
             eval_fn(h)
             if debug_memory:
@@ -161,6 +250,37 @@ def _attention_mask(
     return make_attention_mask(hidden_states, cache=None)
 
 
+def _lfm2_masks(
+    hidden_states: Any,
+    *,
+    sequence_length: int,
+    mask_fn: Callable[..., Any] | None,
+) -> tuple[Any | None, Any | None]:
+    if sequence_length == 1 and mask_fn is None:
+        return None, None
+    if mask_fn is not None:
+        return (
+            _call_mask_fn(mask_fn, hidden_states, kind="attention"),
+            _call_mask_fn(mask_fn, hidden_states, kind="ssm"),
+        )
+    return (
+        make_attention_mask(hidden_states, cache=None),
+        make_ssm_mask(hidden_states, cache=None),
+    )
+
+
+def _call_mask_fn(
+    mask_fn: Callable[..., Any],
+    hidden_states: Any,
+    *,
+    kind: str,
+) -> Any:
+    try:
+        return mask_fn(hidden_states, cache=None, kind=kind)
+    except TypeError:
+        return mask_fn(hidden_states, cache=None)
+
+
 def _run_attention(layer: Any, h: Any, mask: Any | None) -> Any:
     normalized = _call_required(layer, "input_layernorm", h)
     self_attn = getattr(layer, "self_attn", None)
@@ -173,6 +293,33 @@ def _run_attention(layer: Any, h: Any, mask: Any | None) -> Any:
     return h + attention_output
 
 
+def _is_lfm2_attention_layer(layer: Any) -> bool:
+    is_attention_layer = getattr(layer, "is_attention_layer", None)
+    if is_attention_layer is not None:
+        return bool(is_attention_layer)
+    return callable(getattr(layer, "self_attn", None))
+
+
+def _run_lfm2_operator(layer: Any, h: Any, mask: Any | None) -> Any:
+    normalized = _call_required(layer, "operator_norm", h)
+    if _is_lfm2_attention_layer(layer):
+        operator = getattr(layer, "self_attn", None)
+        if not callable(operator):
+            raise ValueError(
+                "LFM2 attention layer does not expose a callable self_attn module."
+            )
+        operator_output = operator(normalized, mask=mask, cache=None)
+    else:
+        operator = getattr(layer, "conv", None)
+        if not callable(operator):
+            raise ValueError("LFM2 conv layer does not expose a callable conv module.")
+        operator_output = operator(normalized, mask=mask, cache=None)
+
+    if isinstance(operator_output, tuple):
+        operator_output = operator_output[0]
+    return h + operator_output
+
+
 def _observe_moe_layer(
     layer: Any,
     moe_input: Any,
@@ -181,6 +328,7 @@ def _observe_moe_layer(
     adapter: Any,
     config: Mapping[str, Any],
 ) -> Any:
+    mx = _require_mlx_core()
     moe = adapter.get_moe(layer)
     routing = Qwen3MoeRouter(moe, config)(moe_input)
     switch_mlp = getattr(moe, "switch_mlp", None)
@@ -188,7 +336,40 @@ def _observe_moe_layer(
         raise ValueError("MoE layer does not expose a callable switch_mlp module.")
 
     selected_outputs = switch_mlp(moe_input, routing.indices)
-    state.accumulate(routing, selected_outputs=selected_outputs)
+    state.accumulate(
+        indices=routing.indices,
+        scores=routing.scores.astype(mx.float32),
+        selected_outputs=selected_outputs.astype(mx.float32),
+    )
+
+    moe_out = (selected_outputs * routing.scores[..., None]).sum(axis=-2)
+    shared_expert = get_shared_expert(moe)
+    if shared_expert is not None:
+        moe_out = moe_out + shared_expert(moe_input)
+    return moe_out
+
+
+def _observe_lfm2_moe_layer(
+    layer: Any,
+    moe_input: Any,
+    state: PruningState,
+    *,
+    adapter: Any,
+    config: Mapping[str, Any],
+) -> Any:
+    mx = _require_mlx_core()
+    moe = adapter.get_moe(layer)
+    routing = Lfm2MoeRouter(moe, config)(moe_input)
+    switch_mlp = getattr(moe, "switch_mlp", None)
+    if not callable(switch_mlp):
+        raise ValueError("MoE layer does not expose a callable switch_mlp module.")
+
+    selected_outputs = switch_mlp(moe_input, routing.indices)
+    state.accumulate(
+        indices=routing.indices,
+        scores=routing.scores.astype(mx.float32),
+        selected_outputs=selected_outputs.astype(mx.float32),
+    )
 
     moe_out = (selected_outputs * routing.scores[..., None]).sum(axis=-2)
     shared_expert = get_shared_expert(moe)

--- a/src/reap/backends/mlx/prune.py
+++ b/src/reap/backends/mlx/prune.py
@@ -13,7 +13,8 @@ from typing import Any
 import numpy as np
 
 from reap.backends.mlx.model_adapters import (
-    Qwen3MoeModelAdapter,
+    infer_model_adapter,
+    update_lfm2_moe_config,
     update_qwen3_moe_config,
 )
 
@@ -51,7 +52,7 @@ def prune_experts(
 
     Returns a mapping from layer index to ascending retained expert indices.
     """
-    adapter = Qwen3MoeModelAdapter() if adapter is None else adapter
+    adapter = infer_model_adapter(model, config) if adapter is None else adapter
     _validate_adapter(adapter)
     _validate_compression_ratio(compression_ratio)
 
@@ -81,13 +82,22 @@ def prune_experts(
         )
         keep_indices = compute_keep_indices(saliency, retained_count)
 
-        _prune_qwen3_moe_layer(
-            adapter.get_moe(layer),
-            keep_indices,
-            num_experts=layer_config.num_experts,
-            old_top_k=layer_config.top_k,
-            layer_idx=layer_idx,
-        )
+        if adapter.adapter_name == "lfm2_moe":
+            _prune_lfm2_moe_layer(
+                adapter.get_moe(layer),
+                keep_indices,
+                num_experts=layer_config.num_experts,
+                old_top_k=layer_config.top_k,
+                layer_idx=layer_idx,
+            )
+        else:
+            _prune_qwen3_moe_layer(
+                adapter.get_moe(layer),
+                keep_indices,
+                num_experts=layer_config.num_experts,
+                old_top_k=layer_config.top_k,
+                layer_idx=layer_idx,
+            )
         keep_by_layer[layer_idx] = keep_indices
 
         new_top_k = min(layer_config.top_k, retained_count)
@@ -96,7 +106,7 @@ def prune_experts(
             config_top_k = new_top_k
         elif config_num_experts != retained_count:
             raise ValueError(
-                "Qwen3-MoE config update requires all pruned layers to retain "
+                "MLX MoE config update requires all pruned layers to retain "
                 f"the same expert count. Layer {layer_idx} retained "
                 f"{retained_count}, expected {config_num_experts}."
             )
@@ -104,7 +114,12 @@ def prune_experts(
             config_top_k = min(config_top_k or new_top_k, new_top_k)
 
     if config_num_experts is not None:
-        update_qwen3_moe_config(
+        update_config = (
+            update_lfm2_moe_config
+            if adapter.adapter_name == "lfm2_moe"
+            else update_qwen3_moe_config
+        )
+        update_config(
             config,
             num_experts=config_num_experts,
             top_k=config_top_k or config_num_experts,
@@ -184,9 +199,10 @@ def slice_first_dim(
 
 def _validate_adapter(adapter: Any) -> None:
     adapter_name = getattr(adapter, "adapter_name", None)
-    if adapter_name != "qwen3_moe":
+    if adapter_name not in {"qwen3_moe", "lfm2_moe"}:
         raise ValueError(
-            "MLX expert pruning currently supports the qwen3_moe adapter only; "
+            "MLX expert pruning currently supports the qwen3_moe and "
+            "lfm2_moe adapters only; "
             f"got {adapter_name!r}."
         )
 
@@ -287,6 +303,73 @@ def _prune_qwen3_moe_layer(
     _update_runtime_attrs(moe, gate, retained_count=retained_count, top_k=new_top_k)
 
 
+def _prune_lfm2_moe_layer(
+    moe: Any,
+    keep_indices: np.ndarray,
+    *,
+    num_experts: int,
+    old_top_k: int,
+    layer_idx: int,
+) -> None:
+    switch_mlp = getattr(moe, "switch_mlp", None)
+    if switch_mlp is None:
+        raise ValueError(f"MoE layer {layer_idx} does not expose switch_mlp.")
+
+    for projection_name in _SWITCH_PROJECTION_NAMES:
+        projection = getattr(switch_mlp, projection_name, None)
+        if projection is None:
+            raise ValueError(
+                f"MoE layer {layer_idx} switch_mlp is missing "
+                f"{projection_name}."
+            )
+        if _get_module_value(projection, "weight") is None:
+            raise ValueError(
+                f"MoE layer {layer_idx} switch_mlp.{projection_name} is "
+                "missing required weight."
+            )
+        slice_first_dim(
+            projection,
+            keep_indices,
+            num_experts=num_experts,
+            required=True,
+        )
+
+    gate = getattr(moe, "gate", None)
+    if gate is None:
+        raise ValueError(f"MoE layer {layer_idx} does not expose a gate.")
+    if _get_module_value(gate, "weight") is None:
+        raise ValueError(f"MoE layer {layer_idx} gate is missing required weight.")
+    slice_first_dim(
+        gate,
+        keep_indices,
+        num_experts=num_experts,
+        required=True,
+        field_names=("weight", "scales", "biases", "bias"),
+    )
+
+    if getattr(moe, "use_expert_bias", False) or hasattr(moe, "expert_bias"):
+        expert_bias = getattr(moe, "expert_bias", None)
+        if expert_bias is None:
+            raise ValueError(
+                f"MoE layer {layer_idx} use_expert_bias is enabled but "
+                "expert_bias is missing."
+            )
+        setattr(
+            moe,
+            "expert_bias",
+            _slice_value_first_dim(
+                expert_bias,
+                keep_indices,
+                num_experts=num_experts,
+                field_name="expert_bias",
+            ),
+        )
+
+    retained_count = len(keep_indices)
+    new_top_k = min(int(old_top_k), retained_count)
+    _update_runtime_attrs(moe, gate, retained_count=retained_count, top_k=new_top_k)
+
+
 def _update_runtime_attrs(
     moe: Any,
     gate: Any,
@@ -320,6 +403,17 @@ def _get_module_value(module: Any, field_name: str) -> Any | None:
 
 def _set_module_value(module: Any, field_name: str, value: Any) -> None:
     setattr(module, field_name, value)
+
+
+def _slice_value_first_dim(
+    value: Any,
+    keep_indices: np.ndarray,
+    *,
+    num_experts: int,
+    field_name: str,
+) -> Any:
+    _validate_first_dim(value, field_name=field_name, num_experts=num_experts)
+    return value[_keep_list(keep_indices)]
 
 
 def _validate_first_dim(value: Any, *, field_name: str, num_experts: int) -> None:

--- a/src/reap/backends/mlx/router.py
+++ b/src/reap/backends/mlx/router.py
@@ -25,7 +25,7 @@ def _require_mlx_core():
         import mlx.core as mx
     except ModuleNotFoundError as exc:
         raise ModuleNotFoundError(
-            "Qwen3MoeRouter requires the optional 'mlx' package to execute. "
+            "MLX router adapters require the optional 'mlx' package to execute. "
             "Install MLX in the active environment before routing."
         ) from exc
     return mx
@@ -133,3 +133,94 @@ class Qwen3MoeRouter:
             logits=None,
             score_mode="actual",
         )
+
+
+class Lfm2MoeRouter:
+    """Liquid LFM2.5 MoE router matching MLX-LM routing semantics."""
+
+    def __init__(
+        self,
+        moe_layer: Any,
+        config: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.gate = getattr(moe_layer, "gate", None)
+        if self.gate is None:
+            raise ValueError("Lfm2MoeRouter requires an MLX MoE layer with a gate.")
+
+        self.top_k = _live_or_config_value(
+            moe_layer,
+            "top_k",
+            config,
+            "num_experts_per_tok",
+            "top_k",
+        )
+        if self.top_k is None:
+            raise ValueError(
+                "Lfm2MoeRouter requires top-k from moe_layer.top_k, "
+                "config['num_experts_per_tok'], or config['top_k']."
+            )
+        self.top_k = int(self.top_k)
+        if self.top_k < 1:
+            raise ValueError(f"top_k must be positive, got {self.top_k}.")
+
+        self.norm_topk_prob = bool(
+            _live_or_config_value(
+                moe_layer,
+                "norm_topk_prob",
+                config,
+                "norm_topk_prob",
+                default=False,
+            )
+        )
+        self.use_expert_bias = bool(
+            _live_or_config_value(
+                moe_layer,
+                "use_expert_bias",
+                config,
+                "use_expert_bias",
+                default=False,
+            )
+        )
+        self.expert_bias = getattr(moe_layer, "expert_bias", None)
+        if self.use_expert_bias and self.expert_bias is None:
+            raise ValueError(
+                "Lfm2MoeRouter requires moe_layer.expert_bias when "
+                "use_expert_bias is enabled."
+            )
+
+    def __call__(self, hidden_states: Any) -> RouterResult:
+        mx = _require_mlx_core()
+
+        if hidden_states.ndim not in (2, 3):
+            raise ValueError(
+                "Lfm2MoeRouter expects hidden states with shape "
+                "[tokens, hidden] or [batch, seq, hidden], got "
+                f"{hidden_states.shape}."
+            )
+
+        logits = self.gate(hidden_states).astype(mx.float32)
+        num_experts = logits.shape[-1]
+        if self.top_k > num_experts:
+            raise ValueError(
+                f"top_k={self.top_k} cannot exceed num_experts={num_experts}."
+            )
+
+        gates = mx.softmax(logits, axis=-1)
+        if self.use_expert_bias:
+            gates = gates + self.expert_bias
+
+        indices = mx.argpartition(gates, kth=-self.top_k, axis=-1)[..., -self.top_k :]
+        scores = mx.take_along_axis(gates, indices, axis=-1)
+        if self.norm_topk_prob:
+            scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+        scores = scores.astype(hidden_states.dtype)
+
+        return RouterResult(
+            indices=indices,
+            scores=scores,
+            logits=None,
+            score_mode="actual",
+        )
+
+
+__all__ = ["Lfm2MoeRouter", "Qwen3MoeRouter", "RouterResult"]

--- a/src/reap/backends/mlx/save.py
+++ b/src/reap/backends/mlx/save.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from reap.backends.mlx.model_adapters import Qwen3MoeModelAdapter
+from reap.backends.mlx.model_adapters import infer_model_adapter
 
 
 _WEIGHT_PATTERNS = ("*.safetensors", "*.npz")
@@ -43,7 +43,7 @@ def save_pruned_model(
     save_fn: Callable[..., Any] | None = None,
 ) -> SaveReloadResult:
     """Save a pruned model, reload it, and validate the reloaded artifact."""
-    adapter = Qwen3MoeModelAdapter() if adapter is None else adapter
+    adapter = infer_model_adapter(model, config) if adapter is None else adapter
     output_path = _prepare_output_dir(output_dir)
     expected_count = _expected_expert_count(config, expected_expert_count)
     save_fn = _default_save_fn() if save_fn is None else save_fn
@@ -254,18 +254,20 @@ def _validate_reloaded_model_shapes(
                 f"Reloaded layer {layer_idx} expert count mismatch: expected "
                 f"{expected_expert_count}, got {layer_config.num_experts}."
             )
-        _validate_qwen3_shapes(
+        _validate_switch_moe_shapes(
             adapter.get_moe(layer),
             expected_expert_count=expected_expert_count,
             layer_idx=layer_idx,
+            validate_expert_bias=adapter.adapter_name == "lfm2_moe",
         )
 
 
-def _validate_qwen3_shapes(
+def _validate_switch_moe_shapes(
     moe: Any,
     *,
     expected_expert_count: int,
     layer_idx: int,
+    validate_expert_bias: bool,
 ) -> None:
     switch_mlp = getattr(moe, "switch_mlp", None)
     if switch_mlp is None:
@@ -292,6 +294,15 @@ def _validate_qwen3_shapes(
         expected_expert_count=expected_expert_count,
         name=f"layer {layer_idx} gate.weight",
     )
+
+    if validate_expert_bias and (
+        getattr(moe, "use_expert_bias", False) or hasattr(moe, "expert_bias")
+    ):
+        _validate_first_dim(
+            getattr(moe, "expert_bias", None),
+            expected_expert_count=expected_expert_count,
+            name=f"layer {layer_idx} expert_bias",
+        )
 
 
 def _validate_first_dim(

--- a/tests/test_mlx_model_adapters.py
+++ b/tests/test_mlx_model_adapters.py
@@ -13,11 +13,14 @@ from types import SimpleNamespace
 import pytest
 
 from reap.backends.mlx.model_adapters import (
+    Lfm2MoeModelAdapter,
     MoeLayerConfig,
     Qwen3MoeModelAdapter,
     get_model_layers,
     get_shared_expert,
+    infer_model_adapter,
     make_attention_mask,
+    update_lfm2_moe_config,
     update_qwen3_moe_config,
 )
 
@@ -48,8 +51,9 @@ def test_model_adapters_module_import_does_not_import_heavy_runtime_packages():
 
         sys.meta_path.insert(0, ImportBlocker())
 
-        from reap.backends.mlx.model_adapters import Qwen3MoeModelAdapter
+        from reap.backends.mlx.model_adapters import Lfm2MoeModelAdapter, Qwen3MoeModelAdapter
 
+        assert Lfm2MoeModelAdapter().adapter_name == "lfm2_moe"
         assert Qwen3MoeModelAdapter().adapter_name == "qwen3_moe"
 
         forbidden_loaded = sorted(
@@ -107,8 +111,16 @@ class MoeMlp:
             self.shared_experts = shared_experts
 
 
+class Lfm2FeedForward(MoeMlp):
+    pass
+
+
 def layer_with_mlp(mlp):
     return SimpleNamespace(mlp=mlp)
+
+
+def layer_with_feed_forward(feed_forward):
+    return SimpleNamespace(feed_forward=feed_forward)
 
 
 def model_model_layers(layers):
@@ -241,6 +253,69 @@ def test_qwen3_adapter_layer_config_requires_expert_count_and_top_k():
         adapter.get_layer_config(layer_with_mlp(MoeMlp(num_experts=2)), {})
 
 
+def test_lfm2_adapter_identifies_feed_forward_moe_layers_after_dense_layers():
+    adapter = Lfm2MoeModelAdapter()
+    layers = [
+        layer_with_feed_forward(DenseMlp()),
+        layer_with_feed_forward(DenseMlp()),
+        layer_with_feed_forward(Lfm2FeedForward()),
+        layer_with_feed_forward(Lfm2FeedForward()),
+    ]
+
+    model = model_model_layers(layers)
+
+    assert adapter.layers(model) is layers
+    assert adapter.identify_moe_layers(model) == [2, 3]
+    assert adapter.get_dense_mlp(layers[0]) is layers[0].feed_forward
+    assert adapter.get_moe(layers[2]) is layers[2].feed_forward
+
+
+def test_lfm2_adapter_layer_config_includes_expert_bias_flag():
+    adapter = Lfm2MoeModelAdapter()
+    feed_forward = Lfm2FeedForward(
+        num_experts=32,
+        top_k=4,
+        norm_topk_prob=True,
+    )
+    feed_forward.use_expert_bias = True
+    layer = layer_with_feed_forward(feed_forward)
+
+    layer_config = adapter.get_layer_config(
+        layer,
+        {
+            "num_experts": 99,
+            "num_experts_per_tok": 8,
+            "norm_topk_prob": False,
+            "use_expert_bias": False,
+        },
+    )
+
+    assert layer_config == MoeLayerConfig(
+        num_experts=32,
+        top_k=4,
+        norm_topk_prob=True,
+        adapter_name="lfm2_moe",
+        use_expert_bias=True,
+    )
+
+
+def test_infer_model_adapter_selects_lfm2_from_config_and_layout():
+    assert infer_model_adapter(config={"model_type": "lfm2_moe"}).adapter_name == (
+        "lfm2_moe"
+    )
+    assert infer_model_adapter(
+        config={"architectures": ["Lfm2MoeForCausalLM"]}
+    ).adapter_name == "lfm2_moe"
+
+    lfm2_model = model_model_layers(
+        [layer_with_feed_forward(DenseMlp()), layer_with_feed_forward(Lfm2FeedForward())]
+    )
+    qwen_model = model_model_layers([layer_with_mlp(MoeMlp())])
+
+    assert infer_model_adapter(lfm2_model, {}).adapter_name == "lfm2_moe"
+    assert infer_model_adapter(qwen_model, {}).adapter_name == "qwen3_moe"
+
+
 def test_get_shared_expert_handles_plural_and_singular_names():
     plural_shared = object()
     singular_shared = object()
@@ -268,6 +343,24 @@ def test_update_qwen3_moe_config_updates_existing_top_k_key_only():
     update_qwen3_moe_config(config, num_experts=3, top_k=2)
 
     assert config == {"num_experts": 3, "num_experts_per_tok": 2, "top_k": 2}
+
+
+def test_update_lfm2_moe_config_preserves_expert_bias_flag_and_clamps_top_k():
+    config = {
+        "model_type": "lfm2_moe",
+        "num_experts": 32,
+        "num_experts_per_tok": 4,
+        "use_expert_bias": True,
+    }
+
+    update_lfm2_moe_config(config, num_experts=2, top_k=4)
+
+    assert config == {
+        "model_type": "lfm2_moe",
+        "num_experts": 2,
+        "num_experts_per_tok": 2,
+        "use_expert_bias": True,
+    }
 
 
 def test_make_attention_mask_requires_mlx_lm_when_missing():

--- a/tests/test_mlx_observer.py
+++ b/tests/test_mlx_observer.py
@@ -187,6 +187,65 @@ class TinyModel:
         self.model.layers = layers
 
 
+class TinyLfmOperator:
+    def __init__(self, mx, value):
+        self.mx = mx
+        self.value = value
+        self.calls = []
+
+    def __call__(self, x, mask=None, cache=None):
+        self.calls.append((mask, cache))
+        return self.mx.ones_like(x) * self.value
+
+
+class TinyLfmGate:
+    def __init__(self, mx):
+        self.mx = mx
+
+    def __call__(self, hidden_states):
+        token_values = hidden_states[..., 0]
+        return self.mx.stack(
+            [
+                1.0 - token_values,
+                token_values,
+                self.mx.zeros_like(token_values) - 2.0,
+            ],
+            axis=-1,
+        )
+
+
+class TinyLfmMoeFeedForward:
+    def __init__(self, mx, *, top_k=1):
+        self.num_experts = 3
+        self.top_k = top_k
+        self.norm_topk_prob = False
+        self.use_expert_bias = False
+        self.gate = TinyLfmGate(mx)
+        self.switch_mlp = TinySwitchMlp(mx)
+
+
+class TinyLfmDenseFeedForward:
+    def __init__(self, mx):
+        self.mx = mx
+        self.inputs = []
+
+    def __call__(self, hidden_states):
+        self.inputs.append(np.asarray(hidden_states))
+        return self.mx.zeros_like(hidden_states)
+
+
+class TinyLfmLayer:
+    def __init__(self, mx, *, is_attention_layer, feed_forward, operator_value=0.0):
+        self.operator_norm = Identity()
+        self.ffn_norm = Identity()
+        self.is_attention_layer = is_attention_layer
+        self.feed_forward = feed_forward
+        if is_attention_layer:
+            self.self_attn = TinyLfmOperator(mx, operator_value)
+        else:
+            self.conv = TinyLfmOperator(mx, operator_value)
+
+
 def _softmax_top_score():
     values = np.exp(np.array([1.0, 0.0, -2.0]))
     return values[0] / values.sum()
@@ -379,3 +438,55 @@ def test_observe_model_rejects_empty_calibration_sequence():
             [[]],
             {"num_experts": 3, "num_experts_per_tok": 1},
         )
+
+
+@requires_mlx
+def test_observe_model_replays_lfm2_conv_attention_dense_and_moe_layers():
+    import mlx.core as mx
+
+    dense_feed_forward = TinyLfmDenseFeedForward(mx)
+    conv_layer = TinyLfmLayer(
+        mx,
+        is_attention_layer=False,
+        feed_forward=dense_feed_forward,
+        operator_value=0.0,
+    )
+    moe_layer = TinyLfmLayer(
+        mx,
+        is_attention_layer=True,
+        feed_forward=TinyLfmMoeFeedForward(mx, top_k=1),
+        operator_value=0.0,
+    )
+    model = TinyModel(mx, [conv_layer, moe_layer])
+    mask_calls = []
+    eval_calls = []
+
+    def mask_fn(hidden_states, cache=None, kind=None):
+        mask_calls.append((hidden_states.shape, cache, kind))
+        return kind
+
+    observer_data = observe_model(
+        model,
+        [[0, 1]],
+        {
+            "model_type": "lfm2_moe",
+            "num_experts": 3,
+            "num_experts_per_tok": 1,
+            "norm_topk_prob": False,
+            "use_expert_bias": False,
+        },
+        mask_fn=mask_fn,
+        eval_fn=lambda h: eval_calls.append(h.shape),
+    )
+
+    assert set(observer_data) == {1}
+    assert set(observer_data[1]) == EXPECTED_PRUNING_KEYS
+    assert mask_calls == [
+        ((1, 2, 2), None, "attention"),
+        ((1, 2, 2), None, "ssm"),
+    ]
+    assert conv_layer.conv.calls == [("ssm", None)]
+    assert moe_layer.self_attn.calls == [("attention", None)]
+    assert eval_calls == [(1, 2, 2), (1, 2, 2)]
+    assert len(dense_feed_forward.inputs) == 1
+    assert np.isfinite(observer_data[1]["reap"]).all()

--- a/tests/test_mlx_prune.py
+++ b/tests/test_mlx_prune.py
@@ -138,6 +138,15 @@ class TinyGate:
         self.top_k = 3
 
 
+class TinyLfmGate(TinyGate):
+    def __init__(self, num_experts: int):
+        super().__init__(num_experts)
+        self.scales = np.arange(num_experts, dtype=np.float32).reshape(num_experts, 1)
+        self.biases = (
+            np.arange(num_experts, dtype=np.float32).reshape(num_experts, 1) + 100
+        )
+
+
 class TinyMoe:
     def __init__(self, num_experts: int = 4, top_k: int = 3):
         self.num_experts = num_experts
@@ -160,12 +169,46 @@ def make_model(num_experts: int = 4, top_k: int = 3):
     )
 
 
+class TinyLfmMoe:
+    def __init__(self, num_experts: int = 32, top_k: int = 4):
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.num_experts_per_tok = top_k
+        self.norm_topk_prob = True
+        self.use_expert_bias = True
+        self.gate = TinyLfmGate(num_experts)
+        self.switch_mlp = TinySwitchMlp(num_experts)
+        self.expert_bias = np.arange(num_experts, dtype=np.float32) + 7000
+
+
+def make_lfm2_model(num_experts: int = 32, top_k: int = 4):
+    moe = TinyLfmMoe(num_experts=num_experts, top_k=top_k)
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[
+                SimpleNamespace(feed_forward=object()),
+                SimpleNamespace(feed_forward=moe),
+            ],
+        ),
+    )
+
+
 def qwen_config(num_experts: int = 4, top_k: int = 3):
     return {
         "num_experts": num_experts,
         "num_experts_per_tok": top_k,
         "top_k": top_k,
         "norm_topk_prob": False,
+    }
+
+
+def lfm2_config(num_experts: int = 32, top_k: int = 4):
+    return {
+        "model_type": "lfm2_moe",
+        "num_experts": num_experts,
+        "num_experts_per_tok": top_k,
+        "norm_topk_prob": True,
+        "use_expert_bias": True,
     }
 
 
@@ -382,3 +425,73 @@ def test_prune_experts_rejects_slice_field_with_wrong_first_dimension():
             "reap",
             0.5,
         )
+
+
+def test_prune_experts_slices_lfm2_switch_gate_expert_bias_and_config():
+    model = make_lfm2_model(num_experts=32, top_k=4)
+    config = lfm2_config(num_experts=32, top_k=4)
+    moe = model.model.layers[1].feed_forward
+    keep = np.arange(16, 32)
+
+    originals = {
+        "gate_proj_weight": moe.switch_mlp.gate_proj.weight.copy(),
+        "gate_proj_scales": moe.switch_mlp.gate_proj.scales.copy(),
+        "gate_proj_biases": moe.switch_mlp.gate_proj.biases.copy(),
+        "gate_weight": moe.gate.weight.copy(),
+        "gate_scales": moe.gate.scales.copy(),
+        "gate_biases": moe.gate.biases.copy(),
+        "expert_bias": moe.expert_bias.copy(),
+    }
+
+    keep_by_layer = prune_experts(
+        model,
+        config,
+        {1: {"reap": np.arange(32, dtype=np.float32)}},
+        "reap",
+        0.5,
+    )
+
+    np.testing.assert_array_equal(keep_by_layer[1], keep)
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.weight,
+        originals["gate_proj_weight"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.scales,
+        originals["gate_proj_scales"][keep],
+    )
+    np.testing.assert_array_equal(
+        moe.switch_mlp.gate_proj.biases,
+        originals["gate_proj_biases"][keep],
+    )
+    np.testing.assert_array_equal(moe.gate.weight, originals["gate_weight"][keep])
+    np.testing.assert_array_equal(moe.gate.scales, originals["gate_scales"][keep])
+    np.testing.assert_array_equal(moe.gate.biases, originals["gate_biases"][keep])
+    np.testing.assert_array_equal(moe.expert_bias, originals["expert_bias"][keep])
+
+    assert moe.num_experts == 16
+    assert moe.top_k == 4
+    assert moe.num_experts_per_tok == 4
+    assert config["num_experts"] == 16
+    assert config["num_experts_per_tok"] == 4
+    assert config["use_expert_bias"] is True
+
+
+def test_prune_experts_clamps_lfm2_top_k_below_retained_count():
+    model = make_lfm2_model(num_experts=4, top_k=3)
+    config = lfm2_config(num_experts=4, top_k=3)
+    moe = model.model.layers[1].feed_forward
+
+    prune_experts(
+        model,
+        config,
+        {1: {"reap": np.array([0.1, 0.9, 0.2, 0.8])}},
+        "reap",
+        0.75,
+    )
+
+    assert moe.num_experts == 1
+    assert moe.top_k == 1
+    assert moe.num_experts_per_tok == 1
+    assert config["num_experts"] == 1
+    assert config["num_experts_per_tok"] == 1

--- a/tests/test_mlx_router.py
+++ b/tests/test_mlx_router.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from reap.backends.mlx.router import Qwen3MoeRouter, RouterResult
+from reap.backends.mlx.router import Lfm2MoeRouter, Qwen3MoeRouter, RouterResult
 
 
 MLX_AVAILABLE = importlib.util.find_spec("mlx") is not None
@@ -53,8 +53,9 @@ def test_router_module_import_does_not_import_heavy_runtime_packages():
 
         sys.meta_path.insert(0, ImportBlocker())
 
-        from reap.backends.mlx.router import Qwen3MoeRouter, RouterResult
+        from reap.backends.mlx.router import Lfm2MoeRouter, Qwen3MoeRouter, RouterResult
 
+        assert Lfm2MoeRouter is not None
         assert Qwen3MoeRouter is not None
         assert RouterResult(indices=1, scores=2).score_mode == "actual"
 
@@ -124,6 +125,22 @@ class TinyMlp:
             self.norm_topk_prob = norm_topk_prob
 
 
+class TinyLfm2Moe(TinyMlp):
+    def __init__(
+        self,
+        mx,
+        *,
+        top_k=None,
+        norm_topk_prob=None,
+        use_expert_bias=False,
+        expert_bias=None,
+    ):
+        super().__init__(mx, top_k=top_k, norm_topk_prob=norm_topk_prob)
+        self.use_expert_bias = use_expert_bias
+        if expert_bias is not None:
+            self.expert_bias = mx.array(expert_bias)
+
+
 def qwen_reference(mx, mlp, hidden_states, top_k, norm_topk_prob):
     leading_shape = hidden_states.shape[:-1]
     flat_hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
@@ -138,6 +155,19 @@ def qwen_reference(mx, mlp, hidden_states, top_k, norm_topk_prob):
 
     output_shape = (*leading_shape, top_k)
     return indices.reshape(output_shape), scores.reshape(output_shape)
+
+
+def lfm2_reference(mx, moe, hidden_states, top_k, norm_topk_prob):
+    logits = moe.gate(hidden_states).astype(mx.float32)
+    gates = mx.softmax(logits, axis=-1)
+    if moe.use_expert_bias:
+        gates = gates + moe.expert_bias
+
+    indices = mx.argpartition(gates, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(gates, indices, axis=-1)
+    if norm_topk_prob:
+        scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+    return indices, scores.astype(hidden_states.dtype)
 
 
 def assert_same_indices(actual, expected):
@@ -296,3 +326,77 @@ def test_qwen_router_prefers_live_top_k_over_config():
     result = Qwen3MoeRouter(mlp, {"num_experts_per_tok": 3})(hidden_states)
 
     assert result.indices.shape == (1, 1)
+
+
+@requires_mlx
+def test_lfm2_router_matches_reference_without_expert_bias():
+    import mlx.core as mx
+
+    moe = TinyLfm2Moe(mx, top_k=2, norm_topk_prob=False)
+    hidden_states = mx.array(
+        [
+            [[0.2, 0.4, 0.6], [1.0, -0.5, 0.25]],
+            [[-0.25, 0.5, 1.25], [0.0, 1.0, -1.0]],
+        ]
+    )
+
+    result = Lfm2MoeRouter(moe)(hidden_states)
+    expected_indices, expected_scores = lfm2_reference(
+        mx,
+        moe,
+        hidden_states,
+        top_k=2,
+        norm_topk_prob=False,
+    )
+
+    assert result.indices.shape == (2, 2, 2)
+    assert result.scores.shape == (2, 2, 2)
+    assert_same_indices(result.indices, expected_indices)
+    assert_allclose(mx, result.scores, expected_scores)
+
+
+@requires_mlx
+def test_lfm2_router_applies_expert_bias_before_top_k_selection():
+    import mlx.core as mx
+
+    moe = TinyLfm2Moe(
+        mx,
+        top_k=1,
+        norm_topk_prob=False,
+        use_expert_bias=True,
+        expert_bias=[0.0, 0.55, 0.0, 0.0],
+    )
+    hidden_states = mx.array([[[1.0, 0.0, 0.0]]])
+
+    result = Lfm2MoeRouter(moe)(hidden_states)
+    expected_indices, expected_scores = lfm2_reference(
+        mx,
+        moe,
+        hidden_states,
+        top_k=1,
+        norm_topk_prob=False,
+    )
+
+    assert result.indices.tolist() == [[[1]]]
+    assert_same_indices(result.indices, expected_indices)
+    assert_allclose(mx, result.scores, expected_scores)
+
+
+@requires_mlx
+def test_lfm2_router_renormalizes_biased_scores_with_epsilon():
+    import mlx.core as mx
+
+    moe = TinyLfm2Moe(
+        mx,
+        top_k=3,
+        norm_topk_prob=True,
+        use_expert_bias=True,
+        expert_bias=[0.0, 0.2, 0.1, 0.0],
+    )
+    hidden_states = mx.array([[[0.5, 0.25, -0.75], [1.0, 1.0, 1.0]]])
+
+    result = Lfm2MoeRouter(moe)(hidden_states)
+    selected_score_sums = result.scores.sum(axis=-1)
+
+    assert result.indices.shape == (1, 2, 3)
+    assert_allclose(mx, selected_score_sums, mx.ones(selected_score_sums.shape))

--- a/tests/test_mlx_save.py
+++ b/tests/test_mlx_save.py
@@ -111,10 +111,47 @@ class TinyMoe:
         self.gate = TinyGate(weight_experts)
 
 
+class TinyLfmMoe(TinyMoe):
+    def __init__(
+        self,
+        num_experts: int,
+        *,
+        weight_experts: int | None = None,
+        expert_bias_experts: int | None = None,
+    ):
+        super().__init__(num_experts, weight_experts=weight_experts)
+        self.use_expert_bias = True
+        expert_bias_experts = (
+            num_experts if expert_bias_experts is None else expert_bias_experts
+        )
+        self.expert_bias = np.zeros((expert_bias_experts,), dtype=np.float32)
+
+
 def make_reloaded_model(num_experts: int, *, weight_experts: int | None = None):
     moe = TinyMoe(num_experts, weight_experts=weight_experts)
     return SimpleNamespace(
         model=SimpleNamespace(layers=[SimpleNamespace(mlp=moe)]),
+    )
+
+
+def make_lfm2_reloaded_model(
+    num_experts: int,
+    *,
+    weight_experts: int | None = None,
+    expert_bias_experts: int | None = None,
+):
+    moe = TinyLfmMoe(
+        num_experts,
+        weight_experts=weight_experts,
+        expert_bias_experts=expert_bias_experts,
+    )
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[
+                SimpleNamespace(feed_forward=object()),
+                SimpleNamespace(feed_forward=moe),
+            ],
+        ),
     )
 
 
@@ -323,6 +360,61 @@ def test_save_pruned_model_rejects_reloaded_shape_mismatch(tmp_path):
                 make_reloaded_model(2, weight_experts=3),
                 object(),
                 {"num_experts": 2},
+            ),
+        )
+
+
+def test_save_pruned_model_validates_lfm2_expert_bias_shape(tmp_path):
+    result = save_pruned_model(
+        object(),
+        object(),
+        {
+            "model_type": "lfm2_moe",
+            "num_experts": 16,
+            "num_experts_per_tok": 4,
+            "use_expert_bias": True,
+        },
+        tmp_path / "saved",
+        "source-model",
+        save_fn=fake_save_factory([]),
+        load_fn=fake_load_factory(
+            make_lfm2_reloaded_model(16),
+            object(),
+            {
+                "model_type": "lfm2_moe",
+                "num_experts": 16,
+                "num_experts_per_tok": 4,
+                "use_expert_bias": True,
+            },
+        ),
+    )
+
+    assert result.expected_expert_count == 16
+
+
+def test_save_pruned_model_rejects_lfm2_expert_bias_shape_mismatch(tmp_path):
+    with pytest.raises(ValueError, match="expert_bias first dimension mismatch"):
+        save_pruned_model(
+            object(),
+            object(),
+            {
+                "model_type": "lfm2_moe",
+                "num_experts": 16,
+                "num_experts_per_tok": 4,
+                "use_expert_bias": True,
+            },
+            tmp_path / "saved",
+            "source-model",
+            save_fn=fake_save_factory([]),
+            load_fn=fake_load_factory(
+                make_lfm2_reloaded_model(16, expert_bias_experts=32),
+                object(),
+                {
+                    "model_type": "lfm2_moe",
+                    "num_experts": 16,
+                    "num_experts_per_tok": 4,
+                    "use_expert_bias": True,
+                },
             ),
         )
 


### PR DESCRIPTION
## Summary
- add Liquid LFM2.5 MLX router and model adapter inference
- add LFM2 hybrid conv/attention observer replay
- extend pruning and save/reload shape validation for LFM2 expert tensors and expert_bias
- add synthetic router, adapter, observer, prune, and save tests

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py tests/test_mlx_model_adapters.py tests/test_mlx_observer.py tests/test_mlx_prune.py tests/test_mlx_save.py tests/test_mlx_data.py tests/test_mlx_cli.py
- git diff --check
- cached real LFM2 observer probe detected 22 MoE layers and 32-expert metrics
- cached real LFM2 in-memory prune probe pruned 32 -> 16 experts while preserving top-k 4

Closes #20