### PR TITLE
Add MLX validation metrics telemetry

### DIFF
--- a/src/reap/backends/mlx/entrypoint.py
+++ b/src/reap/backends/mlx/entrypoint.py
@@ -9,9 +9,11 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from reap.backends.mlx.data import load_calibration_sequences
+from reap.backends.mlx.model_adapters import infer_model_adapter
 from reap.backends.mlx.observer import observe_model
 from reap.backends.mlx.prune import prune_experts, resolve_prune_method
 from reap.backends.mlx.save import generation_smoke, save_pruned_model
+from reap.backends.mlx.validation_metrics import RunMetrics
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +40,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-seq-length", type=int, default=2048)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--metrics-file",
+        default="validation-metrics.json",
+        help="Metrics JSON filename or absolute path for validation telemetry.",
+    )
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument(
         "--no-smoke",
@@ -83,56 +90,100 @@ def main(
     if args.no_smoke:
         smoke_fn = None
 
+    metrics = RunMetrics(args.output_dir, args.metrics_file)
+    metrics.record_runtime()
+    metrics.record_run_config(args)
+    metrics.sample_memory("start")
+    current_phase = "model_load"
+
     try:
         _emit(print_fn, "load: loading MLX-LM model")
-        model, tokenizer, config = load_model_fn(args.model_name)
+        with metrics.phase("model_load"):
+            model, tokenizer, config = load_model_fn(args.model_name)
         if not isinstance(config, Mapping):
             raise ValueError("MLX-LM load must return a mapping config.")
+        adapter = _infer_adapter_safely(model, config)
+        metrics.record_model_metadata(model, config, adapter=adapter)
+        metrics.sample_memory("after_model_load")
 
+        current_phase = "calibration"
         _emit(print_fn, "calibrate: loading calibration sequences")
-        calibration_sequences = load_calibration_sequences_fn(
-            tokenizer,
-            args.dataset_name,
-            split=args.split,
-            dataset_config_name=args.dataset_config_name,
-            max_samples=args.max_samples,
-            max_seq_length=args.max_seq_length,
-            seed=args.seed,
-        )
+        with metrics.phase("calibration"):
+            calibration_sequences = load_calibration_sequences_fn(
+                tokenizer,
+                args.dataset_name,
+                split=args.split,
+                dataset_config_name=args.dataset_config_name,
+                max_samples=args.max_samples,
+                max_seq_length=args.max_seq_length,
+                seed=args.seed,
+            )
         if not calibration_sequences:
             raise RuntimeError("No non-empty calibration sequences were loaded.")
+        metrics.record_calibration(calibration_sequences)
+        metrics.sample_memory("after_calibration")
 
+        current_phase = "observe"
         _emit(print_fn, "observe: collecting pruning metrics")
-        observer_data = observe_model_fn(
-            model,
-            calibration_sequences,
-            config,
-        )
+        with metrics.phase("observe"):
+            observer_data = observe_model_fn(
+                model,
+                calibration_sequences,
+                config,
+            )
+        metrics.record_observer(observer_data, args.prune_method)
+        metrics.sample_memory("after_observe")
 
+        current_phase = "prune"
         _emit(print_fn, "prune: mutating selected experts")
-        prune_experts_fn(
-            model,
-            config,
-            observer_data,
-            args.prune_method,
-            args.compression_ratio,
+        config_before_prune = dict(config)
+        with metrics.phase("prune"):
+            keep_by_layer = prune_experts_fn(
+                model,
+                config,
+                observer_data,
+                args.prune_method,
+                args.compression_ratio,
+            )
+        metrics.record_pruning(
+            keep_by_layer,
+            config_before=config_before_prune,
+            config_after=config,
+            observer_data=observer_data,
         )
+        metrics.sample_memory("after_prune")
 
+        current_phase = "save_reload_smoke"
         _emit(print_fn, "save: saving pruned model and validating reload")
-        result = save_pruned_model_fn(
-            model,
-            tokenizer,
-            config,
-            args.output_dir,
-            args.model_name,
-            smoke_fn=smoke_fn,
-        )
+        with metrics.phase("save_reload_smoke"):
+            result = save_pruned_model_fn(
+                model,
+                tokenizer,
+                config,
+                args.output_dir,
+                args.model_name,
+                adapter=adapter,
+                smoke_fn=smoke_fn,
+            )
+        metrics.record_save_reload(result, adapter=adapter)
+        metrics.sample_memory("after_save_reload_smoke")
+        metrics.write(status="success")
         _emit(print_fn, "reload/smoke: validation complete")
         _emit(print_fn, f"done: saved MLX pruned model to {result.output_dir}")
         return 0
     except KeyboardInterrupt:
         _emit(print_fn, "interrupted: MLX pruning stopped")
         return 130
+    except Exception as exc:
+        try:
+            metrics.sample_memory("failure")
+            metrics.write(
+                status="failed",
+                failure=metrics.failure_payload(current_phase, exc),
+            )
+        except Exception:
+            logger.exception("failed to write MLX validation metrics")
+        raise
 
 
 def _validate_args(args: argparse.Namespace) -> None:
@@ -165,6 +216,14 @@ def _default_load_model(model_name: str) -> tuple[Any, Any, Mapping[str, Any]]:
             "(model, tokenizer, config)."
         )
     return loaded
+
+
+def _infer_adapter_safely(model: Any, config: Mapping[str, Any]) -> Any | None:
+    try:
+        return infer_model_adapter(model, config)
+    except Exception:
+        logger.debug("could not infer MLX model adapter for metrics", exc_info=True)
+        return None
 
 
 def _emit(print_fn: Callable[[str], Any], message: str) -> None:

--- a/src/reap/backends/mlx/save.py
+++ b/src/reap/backends/mlx/save.py
@@ -6,6 +6,7 @@ default save, load, or generation helpers are executed.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +28,7 @@ class SaveReloadResult:
     reloaded_config: Mapping[str, Any]
     expected_expert_count: int
     smoke_result: Any = None
+    metrics: Mapping[str, Any] | None = None
 
 
 def save_pruned_model(
@@ -48,8 +50,10 @@ def save_pruned_model(
     expected_count = _expected_expert_count(config, expected_expert_count)
     save_fn = _default_save_fn() if save_fn is None else save_fn
     load_fn = _default_load_fn() if load_fn is None else load_fn
+    timings: dict[str, float] = {}
 
     try:
+        save_started = time.perf_counter()
         save_fn(
             dst_path=str(output_path),
             src_path_or_repo=str(original_model_name),
@@ -57,17 +61,23 @@ def save_pruned_model(
             tokenizer=tokenizer,
             config=config,
         )
+        timings["save_seconds"] = time.perf_counter() - save_started
     except Exception as exc:
         raise RuntimeError(
             f"Failed to save pruned MLX model to {output_path}."
         ) from exc
 
     _validate_saved_artifacts(output_path)
+    artifact_summary = _artifact_summary(output_path)
 
+    reload_started = time.perf_counter()
     reloaded_model, reloaded_tokenizer, reloaded_config = _load_reloaded_model(
         load_fn,
         output_path,
     )
+    timings["reload_seconds"] = time.perf_counter() - reload_started
+
+    validation_started = time.perf_counter()
     _validate_reloaded_config(reloaded_config, expected_count)
     _validate_reloaded_model_shapes(
         reloaded_model,
@@ -75,13 +85,37 @@ def save_pruned_model(
         adapter=adapter,
         expected_expert_count=expected_count,
     )
+    timings["reload_validation_seconds"] = time.perf_counter() - validation_started
 
     smoke_result = None
+    smoke_metrics = {
+        "enabled": smoke_fn is not None,
+        "completed": False,
+        "prompt": "What is your name?",
+        "max_tokens": 16,
+        "elapsed_seconds": None,
+        "generated_token_count": None,
+        "result_preview": None,
+    }
     if smoke_fn is not None:
+        smoke_started = time.perf_counter()
         smoke_result = smoke_fn(
             reloaded_model,
             reloaded_tokenizer,
             reloaded_config,
+        )
+        smoke_elapsed = time.perf_counter() - smoke_started
+        timings["smoke_seconds"] = smoke_elapsed
+        smoke_metrics.update(
+            {
+                "completed": True,
+                "elapsed_seconds": smoke_elapsed,
+                "generated_token_count": _count_generated_tokens(
+                    reloaded_tokenizer,
+                    smoke_result,
+                ),
+                "result_preview": _preview(smoke_result),
+            }
         )
 
     return SaveReloadResult(
@@ -91,6 +125,11 @@ def save_pruned_model(
         reloaded_config=reloaded_config,
         expected_expert_count=expected_count,
         smoke_result=smoke_result,
+        metrics={
+            "timings": timings,
+            "artifacts": artifact_summary,
+            "smoke": smoke_metrics,
+        },
     )
 
 
@@ -193,6 +232,28 @@ def _validate_saved_artifacts(output_dir: Path) -> None:
             "Saved MLX model is missing weight artifacts matching "
             f"{_WEIGHT_PATTERNS} in {output_dir}."
         )
+
+
+def _artifact_summary(output_dir: Path) -> dict[str, Any]:
+    files = []
+    seen: set[Path] = set()
+    for pattern in _WEIGHT_PATTERNS + ("*.json", "*.model", "*.txt"):
+        for path in output_dir.glob(pattern):
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            files.append(
+                {
+                    "path": str(path.relative_to(output_dir)),
+                    "bytes": path.stat().st_size,
+                }
+            )
+    files.sort(key=lambda item: item["path"])
+    return {
+        "file_count": len(files),
+        "total_bytes": sum(int(item["bytes"]) for item in files),
+        "files": files,
+    }
 
 
 def _load_reloaded_model(load_fn: Callable[..., Any], output_dir: Path) -> tuple[
@@ -323,6 +384,39 @@ def _validate_first_dim(
             f"Reloaded {name} first dimension mismatch: expected "
             f"{expected_expert_count}, got shape {shape}."
         )
+
+
+def _count_generated_tokens(tokenizer: Any, text: Any) -> int | None:
+    if not isinstance(text, str):
+        return None
+
+    encode = getattr(tokenizer, "encode", None)
+    if not callable(encode):
+        return None
+
+    try:
+        token_ids = encode(text, add_special_tokens=False)
+    except TypeError:
+        try:
+            token_ids = encode(text)
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+    try:
+        return len(token_ids)
+    except TypeError:
+        return None
+
+
+def _preview(value: Any, *, max_chars: int = 500) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3] + "..."
 
 
 __all__ = [

--- a/src/reap/backends/mlx/validation_metrics.py
+++ b/src/reap/backends/mlx/validation_metrics.py
@@ -1,0 +1,782 @@
+"""Structured validation telemetry for MLX pruning runs.
+
+The helpers in this module are intentionally import-light. Optional runtime
+packages are imported only inside collection methods so the MLX backend keeps
+its no-heavy-import package boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import platform
+import resource
+import sys
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from reap.backends.mlx.model_adapters import infer_model_adapter
+from reap.backends.mlx.prune import resolve_prune_method
+
+
+_PACKAGE_VERSION_NAMES = (
+    "mlx",
+    "mlx-lm",
+    "datasets",
+    "huggingface-hub",
+    "safetensors",
+)
+_ARTIFACT_PATTERNS = ("*.safetensors", "*.npz", "*.json", "*.model", "*.txt")
+
+
+@dataclass
+class RunMetrics:
+    """Mutable structured metrics for one MLX pruning CLI run."""
+
+    output_dir: str | Path
+    metrics_file: str | Path = "validation-metrics.json"
+    clock: Any = time.perf_counter
+    data: dict[str, Any] = field(init=False)
+    _started_seconds: float = field(init=False)
+    _phase_starts: dict[str, float] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        self.output_dir = Path(self.output_dir)
+        self.metrics_file = Path(self.metrics_file)
+        self._started_seconds = float(self.clock())
+        self.data = {
+            "status": "running",
+            "started_at": _utc_now(),
+            "finished_at": None,
+            "duration_seconds": None,
+            "model": {},
+            "runtime": {},
+            "run_config": {},
+            "memory": {"samples": {}},
+            "timings": {"phases": {}, "phase_percentages": {}},
+            "throughput": {},
+            "observer": {},
+            "pruning": {},
+            "save_reload": {},
+            "smoke": {},
+            "failure": None,
+        }
+
+    @property
+    def path(self) -> Path:
+        """Return the destination path for the metrics JSON artifact."""
+        if self.metrics_file.is_absolute():
+            return self.metrics_file
+        return self.output_dir / self.metrics_file
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        """Time a named phase."""
+        self.start_phase(name)
+        try:
+            yield
+        finally:
+            self.finish_phase(name)
+
+    def start_phase(self, name: str) -> None:
+        """Mark ``name`` as currently running."""
+        self._phase_starts[name] = float(self.clock())
+
+    def finish_phase(self, name: str) -> float:
+        """Finish a phase and return elapsed seconds."""
+        started = self._phase_starts.pop(name, None)
+        if started is None:
+            return 0.0
+
+        elapsed = max(float(self.clock()) - started, 0.0)
+        self.data["timings"]["phases"][name] = elapsed
+        return elapsed
+
+    def sample_memory(self, label: str) -> dict[str, Any]:
+        """Record MLX and process memory for a named point in the run."""
+        sample = {
+            "timestamp": _utc_now(),
+            "mlx": _sample_mlx_memory(),
+            "process": _sample_process_memory(),
+        }
+        self.data["memory"]["samples"][label] = sample
+        return sample
+
+    def record_runtime(self) -> None:
+        """Record Python, platform, and package version metadata."""
+        self.data["runtime"] = {
+            "python": sys.version,
+            "python_executable": sys.executable,
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+            "package_versions": {
+                name: _package_version(name) for name in _PACKAGE_VERSION_NAMES
+            },
+            "process": _sample_process_memory(),
+        }
+
+    def record_run_config(self, args: Any) -> None:
+        """Record user-facing CLI configuration."""
+        model_name = getattr(args, "model_name", None)
+        self.data["run_config"].update(
+            {
+                "model_name": model_name,
+                "dataset_name": getattr(args, "dataset_name", None),
+                "dataset_config_name": getattr(args, "dataset_config_name", None),
+                "split": getattr(args, "split", None),
+                "seed": getattr(args, "seed", None),
+                "max_samples": getattr(args, "max_samples", None),
+                "max_seq_length": getattr(args, "max_seq_length", None),
+                "prune_method": getattr(args, "prune_method", None),
+                "resolved_prune_method": _resolve_method_or_none(
+                    getattr(args, "prune_method", None)
+                ),
+                "compression_ratio": getattr(args, "compression_ratio", None),
+                "output_dir": str(getattr(args, "output_dir", self.output_dir)),
+                "metrics_file": str(getattr(args, "metrics_file", self.metrics_file)),
+                "smoke_enabled": not bool(getattr(args, "no_smoke", False)),
+            }
+        )
+        self.data["model"]["model_name"] = model_name
+
+    def record_model_metadata(
+        self,
+        model: Any,
+        config: Mapping[str, Any],
+        *,
+        adapter: Any | None = None,
+    ) -> None:
+        """Record model config and adapter-visible architecture facts."""
+        adapter = _safe_adapter(model, config, adapter)
+        layers = _safe_layers(adapter, model)
+        moe_layer_indices = _safe_moe_layers(adapter, model)
+        dense_layer_indices = [
+            idx for idx in range(len(layers)) if idx not in set(moe_layer_indices)
+        ]
+        before_layer_config = _first_layer_config(adapter, layers, config)
+
+        self.data["model"].update(
+            {
+                "model_name": self.data["model"].get("model_name")
+                or config.get("_name_or_path"),
+                "model_revision": config.get("_commit_hash") or config.get("revision"),
+                "model_source_path": _first_attr(
+                    model,
+                    "model_path",
+                    "path",
+                    "name_or_path",
+                ),
+                "adapter_name": getattr(adapter, "adapter_name", None),
+                "model_type": config.get("model_type"),
+                "architectures": _json_safe(config.get("architectures")),
+                "quantization": _json_safe(config.get("quantization")),
+                "quantization_config": _json_safe(config.get("quantization_config")),
+                "hidden_size": config.get("hidden_size"),
+                "num_hidden_layers": config.get("num_hidden_layers", len(layers)),
+                "layer_count": len(layers) if layers else config.get("num_hidden_layers"),
+                "layer_types": _json_safe(config.get("layer_types")),
+                "moe_layer_indices": moe_layer_indices,
+                "dense_layer_indices": dense_layer_indices,
+                "moe_layer_count": len(moe_layer_indices),
+                "expert_count_before": _layer_config_value(
+                    before_layer_config,
+                    "num_experts",
+                    config.get("num_experts"),
+                ),
+                "top_k_before": _layer_config_value(
+                    before_layer_config,
+                    "top_k",
+                    config.get("num_experts_per_tok", config.get("top_k")),
+                ),
+                "norm_topk_prob": _layer_config_value(
+                    before_layer_config,
+                    "norm_topk_prob",
+                    config.get("norm_topk_prob"),
+                ),
+                "use_expert_bias": _layer_config_value(
+                    before_layer_config,
+                    "use_expert_bias",
+                    config.get("use_expert_bias"),
+                ),
+                "first_moe_shapes_before": _first_moe_shape_summary(
+                    adapter,
+                    layers,
+                ),
+            }
+        )
+
+    def record_calibration(self, calibration_sequences: list[Any]) -> None:
+        """Record sample and token counts for loaded calibration sequences."""
+        token_counts = [_sequence_length(sequence) for sequence in calibration_sequences]
+        total_tokens = sum(token_counts)
+        self.data["run_config"].update(
+            {
+                "actual_sample_count": len(calibration_sequences),
+                "actual_total_tokens": total_tokens,
+                "actual_token_counts": token_counts,
+                "actual_min_tokens": min(token_counts) if token_counts else 0,
+                "actual_max_tokens": max(token_counts) if token_counts else 0,
+                "actual_mean_tokens": (
+                    total_tokens / len(token_counts) if token_counts else 0.0
+                ),
+            }
+        )
+
+    def record_observer(
+        self,
+        observer_data: Mapping[int, Mapping[str, Any]],
+        prune_method: str,
+    ) -> None:
+        """Record per-layer observer summary and saliency finite counts."""
+        resolved_method = _resolve_method_or_none(prune_method) or prune_method
+        per_layer: dict[str, Any] = {}
+        total_tokens = 0
+
+        for layer_idx, layer_data in sorted(observer_data.items()):
+            layer_key = str(layer_idx)
+            layer_tokens = int(layer_data.get("total_tokens", 0))
+            total_tokens += layer_tokens
+            frequency = _numeric_list(layer_data.get("expert_frequency", []))
+            saliency = _numeric_list(layer_data.get(resolved_method, []))
+            finite_saliency = [
+                value for value in saliency if isinstance(value, float) and math.isfinite(value)
+            ]
+            non_finite_count = len(saliency) - len(finite_saliency)
+
+            per_layer[layer_key] = {
+                "total_tokens": layer_tokens,
+                "expert_frequency_sum": int(sum(frequency)),
+                "saliency_key": resolved_method,
+                "saliency_count": len(saliency),
+                "saliency_finite_count": len(finite_saliency),
+                "saliency_non_finite_count": non_finite_count,
+                "saliency_min": min(finite_saliency) if finite_saliency else None,
+                "saliency_max": max(finite_saliency) if finite_saliency else None,
+                "saliency_mean": (
+                    sum(finite_saliency) / len(finite_saliency)
+                    if finite_saliency
+                    else None
+                ),
+            }
+
+        self.data["observer"] = {
+            "observed_moe_layer_count": len(observer_data),
+            "observed_moe_layer_indices": [int(idx) for idx in sorted(observer_data)],
+            "total_input_tokens": total_tokens,
+            "per_layer": per_layer,
+        }
+
+    def record_pruning(
+        self,
+        keep_by_layer: Mapping[int, Any] | None,
+        *,
+        config_before: Mapping[str, Any],
+        config_after: Mapping[str, Any],
+        observer_data: Mapping[int, Mapping[str, Any]],
+    ) -> None:
+        """Record retained experts and before/after expert counts."""
+        keep_by_layer = {} if keep_by_layer is None else keep_by_layer
+        per_layer: dict[str, Any] = {}
+        total_removed = 0
+
+        for layer_idx, keep_indices in sorted(keep_by_layer.items()):
+            keep_list = [int(idx) for idx in _list_like(keep_indices)]
+            original_count = _original_expert_count(
+                observer_data.get(int(layer_idx), {}),
+                config_before,
+            )
+            removed_count = max(original_count - len(keep_list), 0)
+            total_removed += removed_count
+            per_layer[str(layer_idx)] = {
+                "original_expert_count": original_count,
+                "retained_expert_count": len(keep_list),
+                "removed_expert_count": removed_count,
+                "retained_indices": keep_list,
+            }
+
+        top_k_before = config_before.get(
+            "num_experts_per_tok",
+            config_before.get("top_k"),
+        )
+        top_k_after = config_after.get("num_experts_per_tok", config_after.get("top_k"))
+        self.data["pruning"] = {
+            "layer_count": len(keep_by_layer),
+            "total_experts_removed": total_removed,
+            "expert_count_before": config_before.get("num_experts"),
+            "expert_count_after": config_after.get("num_experts"),
+            "top_k_before": top_k_before,
+            "top_k_after": top_k_after,
+            "top_k_was_clamped": (
+                top_k_before is not None
+                and top_k_after is not None
+                and int(top_k_after) < int(top_k_before)
+            ),
+            "per_layer": per_layer,
+        }
+        self.data["model"]["expert_count_after"] = config_after.get("num_experts")
+        self.data["model"]["top_k_after"] = top_k_after
+
+    def record_save_reload(
+        self,
+        result: Any,
+        *,
+        adapter: Any | None = None,
+    ) -> None:
+        """Record save/reload artifact, shape validation, and smoke metrics."""
+        output_dir = Path(getattr(result, "output_dir", self.output_dir))
+        result_metrics = getattr(result, "metrics", None) or {}
+        artifact_summary = result_metrics.get("artifacts") or _artifact_summary(
+            output_dir
+        )
+        reloaded_config = getattr(result, "reloaded_config", {}) or {}
+        reloaded_model = getattr(result, "reloaded_model", None)
+        reloaded_moe_layers = _safe_moe_layers(adapter, reloaded_model)
+
+        self.data["save_reload"] = {
+            "output_dir": str(output_dir),
+            "expected_expert_count": getattr(result, "expected_expert_count", None),
+            "reloaded_config_expert_count": reloaded_config.get("num_experts"),
+            "reloaded_adapter_moe_layer_count": len(reloaded_moe_layers),
+            "reloaded_adapter_moe_layer_indices": reloaded_moe_layers,
+            "artifacts": artifact_summary,
+            "timings": result_metrics.get("timings", {}),
+            "shape_summary": _reloaded_shape_summary(adapter, reloaded_model),
+        }
+
+        self.data["smoke"] = result_metrics.get(
+            "smoke",
+            {
+                "enabled": getattr(result, "smoke_result", None) is not None,
+                "completed": getattr(result, "smoke_result", None) is not None,
+                "result_preview": _preview(getattr(result, "smoke_result", None)),
+            },
+        )
+
+    def write(
+        self,
+        *,
+        status: str,
+        failure: Mapping[str, Any] | None = None,
+    ) -> Path:
+        """Finalize and write the metrics JSON artifact."""
+        self.data["status"] = status
+        self.data["finished_at"] = _utc_now()
+        self.data["duration_seconds"] = max(
+            float(self.clock()) - self._started_seconds,
+            0.0,
+        )
+        self.data["failure"] = _json_safe(failure)
+        self._derive_phase_percentages()
+        self._derive_throughput()
+
+        path = self.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(_json_safe(self.data), indent=2, sort_keys=True, allow_nan=False)
+            + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def failure_payload(self, phase: str, exc: BaseException) -> dict[str, Any]:
+        """Build a JSON-safe failure record for ``exc``."""
+        return {
+            "phase": phase,
+            "type": exc.__class__.__name__,
+            "message": str(exc),
+            "elapsed_seconds_before_failure": max(
+                float(self.clock()) - self._started_seconds,
+                0.0,
+            ),
+            "memory_at_failure": self.data["memory"]["samples"].get("failure"),
+        }
+
+    def _derive_phase_percentages(self) -> None:
+        total = float(self.data.get("duration_seconds") or 0.0)
+        phases = self.data["timings"]["phases"]
+        percentages = {}
+        for name, seconds in phases.items():
+            percentages[name] = (seconds / total * 100.0) if total > 0 else None
+        self.data["timings"]["phase_percentages"] = percentages
+
+    def _derive_throughput(self) -> None:
+        phases = self.data["timings"]["phases"]
+        run_config = self.data["run_config"]
+        observer = self.data["observer"]
+        pruning = self.data["pruning"]
+        save_reload = self.data["save_reload"]
+        smoke = self.data["smoke"]
+
+        sample_count = int(run_config.get("actual_sample_count") or 0)
+        total_tokens = int(run_config.get("actual_total_tokens") or 0)
+        observed_layers = int(observer.get("observed_moe_layer_count") or 0)
+        pruning_layers = int(pruning.get("layer_count") or 0)
+        experts_removed = int(pruning.get("total_experts_removed") or 0)
+        artifact_bytes = int(
+            (save_reload.get("artifacts") or {}).get("total_bytes") or 0
+        )
+
+        calibration_seconds = phases.get("calibration", 0.0)
+        observe_seconds = phases.get("observe", 0.0)
+        prune_seconds = phases.get("prune", 0.0)
+        save_reload_timings = save_reload.get("timings") or {}
+        smoke_seconds = smoke.get("elapsed_seconds")
+        generated_tokens = smoke.get("generated_token_count")
+
+        self.data["throughput"] = {
+            "calibration_samples_per_second": _rate(sample_count, calibration_seconds),
+            "calibration_tokens_per_second": _rate(total_tokens, calibration_seconds),
+            "observer_input_tokens_per_second": _rate(total_tokens, observe_seconds),
+            "observer_layer_tokens_per_second": _rate(
+                total_tokens * observed_layers,
+                observe_seconds,
+            ),
+            "observer_layers_per_second": _rate(observed_layers, observe_seconds),
+            "observer_seconds_per_layer": _rate(observe_seconds, observed_layers),
+            "pruning_layers_per_second": _rate(pruning_layers, prune_seconds),
+            "pruning_experts_per_second": _rate(experts_removed, prune_seconds),
+            "save_mb_per_second": _rate(
+                artifact_bytes / 1_000_000,
+                save_reload_timings.get("save_seconds"),
+            ),
+            "reload_mb_per_second": _rate(
+                artifact_bytes / 1_000_000,
+                save_reload_timings.get("reload_seconds"),
+            ),
+            "generation_tokens_per_second": _rate(generated_tokens, smoke_seconds),
+        }
+
+
+def _safe_adapter(
+    model: Any,
+    config: Mapping[str, Any],
+    adapter: Any | None,
+) -> Any | None:
+    if adapter is not None:
+        return adapter
+    try:
+        return infer_model_adapter(model, config)
+    except Exception:
+        return None
+
+
+def _safe_layers(adapter: Any | None, model: Any) -> list[Any]:
+    if adapter is None or model is None:
+        return []
+    try:
+        return list(adapter.layers(model))
+    except Exception:
+        return []
+
+
+def _safe_moe_layers(adapter: Any | None, model: Any) -> list[int]:
+    if adapter is None or model is None:
+        return []
+    try:
+        return [int(idx) for idx in adapter.identify_moe_layers(model)]
+    except Exception:
+        return []
+
+
+def _first_layer_config(
+    adapter: Any | None,
+    layers: list[Any],
+    config: Mapping[str, Any],
+) -> Any | None:
+    if adapter is None:
+        return None
+    for layer in layers:
+        try:
+            if adapter.is_moe_layer(layer):
+                return adapter.get_layer_config(layer, config)
+        except Exception:
+            continue
+    return None
+
+
+def _first_moe_shape_summary(
+    adapter: Any | None,
+    layers: list[Any],
+) -> dict[str, Any]:
+    if adapter is None:
+        return {}
+    for layer_idx, layer in enumerate(layers):
+        try:
+            if adapter.is_moe_layer(layer):
+                return {
+                    "layer_idx": layer_idx,
+                    "shapes": _moe_shape_summary(adapter.get_moe(layer)),
+                }
+        except Exception:
+            continue
+    return {}
+
+
+def _reloaded_shape_summary(adapter: Any | None, model: Any) -> dict[str, Any]:
+    if adapter is None or model is None:
+        return {}
+    layers = _safe_layers(adapter, model)
+    shape_summary = {}
+    for layer_idx in _safe_moe_layers(adapter, model):
+        try:
+            moe = adapter.get_moe(layers[layer_idx])
+        except Exception:
+            continue
+        shape_summary[str(layer_idx)] = _moe_shape_summary(moe)
+    return shape_summary
+
+
+def _moe_shape_summary(moe: Any) -> dict[str, Any]:
+    switch_mlp = getattr(moe, "switch_mlp", None)
+    summary: dict[str, Any] = {
+        "gate": _field_shapes(
+            getattr(moe, "gate", None),
+            ("weight", "scales", "biases", "bias"),
+        ),
+        "expert_bias": _shape(getattr(moe, "expert_bias", None)),
+        "switch_mlp": {},
+    }
+
+    if switch_mlp is not None:
+        for projection_name in ("gate_proj", "up_proj", "down_proj"):
+            summary["switch_mlp"][projection_name] = _field_shapes(
+                getattr(switch_mlp, projection_name, None),
+                ("weight", "scales", "biases", "bias"),
+            )
+    return summary
+
+
+def _field_shapes(module: Any, field_names: tuple[str, ...]) -> dict[str, Any]:
+    if module is None:
+        return {}
+    return {
+        field_name: _shape(_get_module_value(module, field_name))
+        for field_name in field_names
+        if _get_module_value(module, field_name) is not None
+    }
+
+
+def _get_module_value(module: Any, field_name: str) -> Any | None:
+    getter = getattr(module, "get", None)
+    if callable(getter):
+        try:
+            value = getter(field_name)
+        except (KeyError, TypeError, AttributeError):
+            value = None
+        if value is not None:
+            return value
+    return getattr(module, field_name, None)
+
+
+def _shape(value: Any) -> list[int] | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    return [int(dim) for dim in shape]
+
+
+def _first_attr(root: Any, *attrs: str) -> Any:
+    for attr in attrs:
+        value = getattr(root, attr, None)
+        if value is not None and not callable(value):
+            return _json_safe(value)
+    return None
+
+
+def _layer_config_value(layer_config: Any | None, attr: str, default: Any) -> Any:
+    if layer_config is None:
+        return default
+    return getattr(layer_config, attr, default)
+
+
+def _sequence_length(sequence: Any) -> int:
+    input_ids = sequence.get("input_ids") if isinstance(sequence, Mapping) else sequence
+    shape = getattr(input_ids, "shape", None)
+    if shape:
+        return int(shape[-1])
+
+    values = _list_like(input_ids)
+    if values and isinstance(values[0], (list, tuple)):
+        return len(values[0])
+    return len(values)
+
+
+def _original_expert_count(
+    layer_data: Mapping[str, Any],
+    config_before: Mapping[str, Any],
+) -> int:
+    frequency = layer_data.get("expert_frequency")
+    if frequency is not None:
+        shape = getattr(frequency, "shape", None)
+        if shape:
+            return int(shape[0])
+        try:
+            return len(frequency)
+        except TypeError:
+            pass
+    return int(config_before.get("num_experts") or 0)
+
+
+def _numeric_list(value: Any) -> list[float]:
+    values = _list_like(value)
+    result = []
+    for item in values:
+        try:
+            result.append(float(item))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def _list_like(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    try:
+        return list(value)
+    except TypeError:
+        return [value]
+
+
+def _resolve_method_or_none(prune_method: str | None) -> str | None:
+    if prune_method is None:
+        return None
+    try:
+        return resolve_prune_method(prune_method)
+    except ValueError:
+        return None
+
+
+def _artifact_summary(output_dir: Path) -> dict[str, Any]:
+    files = []
+    seen: set[Path] = set()
+    for pattern in _ARTIFACT_PATTERNS:
+        for path in output_dir.glob(pattern):
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            files.append(
+                {
+                    "path": str(path.relative_to(output_dir)),
+                    "bytes": path.stat().st_size,
+                }
+            )
+    files.sort(key=lambda item: item["path"])
+    return {
+        "file_count": len(files),
+        "total_bytes": sum(int(item["bytes"]) for item in files),
+        "files": files,
+    }
+
+
+def _sample_mlx_memory() -> dict[str, Any]:
+    try:
+        import mlx.core as mx
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": exc.__class__.__name__,
+        }
+
+    sample: dict[str, Any] = {"available": True}
+    for key, attr in (
+        ("active_bytes", "get_active_memory"),
+        ("peak_bytes", "get_peak_memory"),
+        ("cache_bytes", "get_cache_memory"),
+    ):
+        getter = getattr(mx, attr, None)
+        if callable(getter):
+            try:
+                sample[key] = int(getter())
+            except Exception as exc:
+                sample[key] = None
+                sample[f"{key}_error"] = exc.__class__.__name__
+        else:
+            sample[key] = None
+    return sample
+
+
+def _sample_process_memory() -> dict[str, Any]:
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    return {
+        "max_rss": int(usage.ru_maxrss),
+        "max_rss_units": "platform_ru_maxrss",
+    }
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _rate(numerator: Any, seconds: Any) -> float | None:
+    if numerator is None or seconds is None:
+        return None
+    try:
+        numerator = float(numerator)
+        seconds = float(seconds)
+    except (TypeError, ValueError):
+        return None
+    if seconds <= 0:
+        return None
+    return numerator / seconds
+
+
+def _preview(value: Any, *, max_chars: int = 500) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3] + "..."
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, str | bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Path):
+        return str(value)
+    if hasattr(value, "item"):
+        try:
+            return _json_safe(value.item())
+        except Exception:
+            pass
+    if hasattr(value, "tolist"):
+        try:
+            return _json_safe(value.tolist())
+        except Exception:
+            pass
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_json_safe(item) for item in value]
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        return {
+            "type": value.__class__.__name__,
+            "shape": [int(dim) for dim in shape],
+        }
+    return str(value)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = ["RunMetrics"]

--- a/tests/test_mlx_cli.py
+++ b/tests/test_mlx_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -228,6 +229,14 @@ def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_pa
     assert any("reload/smoke:" in line for line in output)
     assert any("done:" in line for line in output)
 
+    metrics_path = tmp_path / "pruned" / "validation-metrics.json"
+    payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "success"
+    assert payload["run_config"]["model_name"] == "mlx-model"
+    assert payload["run_config"]["actual_sample_count"] == 1
+    assert payload["pruning"]["expert_count_before"] == 4
+    assert payload["pruning"]["expert_count_after"] == 3
+
 
 def test_no_smoke_passes_no_smoke_function_to_save(tmp_path):
     save_kwargs = {}
@@ -283,3 +292,41 @@ def test_keyboard_interrupt_returns_130_without_success_message():
     assert code == 130
     assert any("interrupted:" in line for line in output)
     assert not any("done:" in line for line in output)
+
+
+def test_main_writes_failed_metrics_when_pipeline_phase_raises(tmp_path):
+    output_dir = tmp_path / "failed-run"
+
+    def fail_observe(model, sequences, config):
+        del model, sequences, config
+        raise RuntimeError("observer failed")
+
+    with pytest.raises(RuntimeError, match="observer failed"):
+        main(
+            [
+                "--model-name",
+                "model",
+                "--dataset-name",
+                "dataset",
+                "--output-dir",
+                str(output_dir),
+            ],
+            load_model_fn=lambda model_name: (
+                object(),
+                object(),
+                {"num_experts": 1, "num_experts_per_tok": 1},
+            ),
+            load_calibration_sequences_fn=lambda *args, **kwargs: [
+                {"input_ids": [1, 2]},
+            ],
+            observe_model_fn=fail_observe,
+            print_fn=lambda message: None,
+        )
+
+    payload = json.loads(
+        (output_dir / "validation-metrics.json").read_text(encoding="utf-8")
+    )
+    assert payload["status"] == "failed"
+    assert payload["failure"]["phase"] == "observe"
+    assert payload["failure"]["type"] == "RuntimeError"
+    assert payload["failure"]["message"] == "observer failed"

--- a/tests/test_mlx_validation_metrics.py
+++ b/tests/test_mlx_validation_metrics.py
@@ -1,0 +1,222 @@
+"""Tests for MLX validation metrics telemetry."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from reap.backends.mlx.validation_metrics import RunMetrics
+
+
+def _subprocess_with_import_blocker(body: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    code = textwrap.dedent(
+        f"""
+        import sys
+
+        BLOCKED_ROOTS = ("torch", "vllm", "mlx", "mlx_lm", "datasets")
+
+        def is_blocked(fullname):
+            return any(
+                fullname == root or fullname.startswith(root + ".")
+                for root in BLOCKED_ROOTS
+            )
+
+        class ImportBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if is_blocked(fullname):
+                    raise AssertionError(
+                        "forbidden import during MLX metrics import: "
+                        f"{{fullname}}"
+                    )
+                return None
+
+        sys.meta_path.insert(0, ImportBlocker())
+
+        {body}
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class FakeClock:
+    def __init__(self):
+        self.value = 0.0
+
+    def __call__(self):
+        return self.value
+
+    def advance(self, seconds: float):
+        self.value += seconds
+
+
+class TinyMoe:
+    switch_mlp = object()
+    num_experts = 4
+    top_k = 2
+    norm_topk_prob = True
+
+
+def test_validation_metrics_import_does_not_import_heavy_runtime_packages():
+    result = _subprocess_with_import_blocker(
+        """
+        from reap.backends.mlx.validation_metrics import RunMetrics
+
+        assert RunMetrics is not None
+
+        forbidden_loaded = sorted(
+            name for name in sys.modules if is_blocked(name)
+        )
+        if forbidden_loaded:
+            raise AssertionError(
+                "forbidden modules loaded during MLX metrics import: "
+                + ", ".join(forbidden_loaded)
+            )
+        """
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_run_metrics_writes_success_json_with_timings_and_throughput(tmp_path):
+    clock = FakeClock()
+    metrics = RunMetrics(tmp_path, clock=clock)
+
+    args = SimpleNamespace(
+        model_name="model",
+        dataset_name="dataset",
+        dataset_config_name=None,
+        split="train",
+        seed=42,
+        max_samples=2,
+        max_seq_length=8,
+        prune_method="reap",
+        compression_ratio=0.25,
+        output_dir=str(tmp_path),
+        metrics_file="validation-metrics.json",
+        no_smoke=False,
+    )
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[
+                SimpleNamespace(mlp=TinyMoe()),
+                SimpleNamespace(mlp=object()),
+            ],
+        ),
+    )
+    config = {
+        "model_type": "qwen3_moe",
+        "architectures": ["Qwen3MoeForCausalLM"],
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "num_hidden_layers": 2,
+    }
+
+    metrics.record_run_config(args)
+    metrics.record_model_metadata(model, config)
+
+    with metrics.phase("calibration"):
+        clock.advance(2.0)
+    calibration_sequences = [{"input_ids": np.array([1, 2, 3])}, {"input_ids": [4]}]
+    metrics.record_calibration(calibration_sequences)
+
+    observer_data = {
+        0: {
+            "total_tokens": 4,
+            "expert_frequency": np.array([2, 1, 1, 0]),
+            "reap": np.array([1.0, np.nan, np.inf, 0.5]),
+        }
+    }
+    with metrics.phase("observe"):
+        clock.advance(4.0)
+    metrics.record_observer(observer_data, "reap")
+
+    with metrics.phase("prune"):
+        clock.advance(1.0)
+    metrics.record_pruning(
+        {0: [0, 1, 3]},
+        config_before=config,
+        config_after={"num_experts": 3, "num_experts_per_tok": 2},
+        observer_data=observer_data,
+    )
+
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "model.safetensors").write_bytes(b"weights")
+    metrics.record_save_reload(
+        SimpleNamespace(
+            output_dir=tmp_path,
+            reloaded_config={"num_experts": 3},
+            expected_expert_count=3,
+            smoke_result="hello",
+            metrics={
+                "timings": {
+                    "save_seconds": 0.5,
+                    "reload_seconds": 0.25,
+                    "smoke_seconds": 0.1,
+                },
+                "artifacts": {
+                    "file_count": 2,
+                    "total_bytes": 9,
+                    "files": [],
+                },
+                "smoke": {
+                    "enabled": True,
+                    "completed": True,
+                    "elapsed_seconds": 0.1,
+                    "generated_token_count": 2,
+                    "result_preview": "hello",
+                },
+            },
+        )
+    )
+
+    clock.advance(1.0)
+    path = metrics.write(status="success")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["status"] == "success"
+    assert payload["duration_seconds"] == 8.0
+    assert payload["model"]["moe_layer_indices"] == [0]
+    assert payload["run_config"]["actual_total_tokens"] == 4
+    assert payload["observer"]["per_layer"]["0"]["saliency_finite_count"] == 2
+    assert payload["observer"]["per_layer"]["0"]["saliency_non_finite_count"] == 2
+    assert payload["pruning"]["total_experts_removed"] == 1
+    assert payload["save_reload"]["artifacts"]["total_bytes"] == 9
+    assert payload["throughput"]["calibration_tokens_per_second"] == 2.0
+    assert payload["throughput"]["generation_tokens_per_second"] == 20.0
+
+
+def test_run_metrics_writes_failure_payload(tmp_path):
+    clock = FakeClock()
+    metrics = RunMetrics(tmp_path, clock=clock)
+    metrics.sample_memory("failure")
+    clock.advance(3.0)
+
+    error = RuntimeError("boom")
+    path = metrics.write(
+        status="failed",
+        failure=metrics.failure_payload("observe", error),
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["status"] == "failed"
+    assert payload["failure"]["phase"] == "observe"
+    assert payload["failure"]["type"] == "RuntimeError"
+    assert payload["failure"]["message"] == "boom"


### PR DESCRIPTION
## Summary

Adds structured validation telemetry for the MLX pruning CLI so the upcoming LFM2.5 real E2E run can save correctness, runtime, memory, timing, throughput, pruning, save/reload, and smoke-generation metrics to `validation-metrics.json`.

Refs #9.

## Changes

- Add import-light `RunMetrics` helper for JSON validation telemetry.
- Wire MLX CLI phase timing, memory sampling, observer/pruning summaries, success metrics, and failure diagnostics.
- Extend save/reload helper with artifact summaries, save/reload/smoke timings, and smoke result preview/token counting when possible.
- Add `--metrics-file` CLI option, defaulting to `validation-metrics.json` in the output dir.

## Validation

```bash
PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mlx_no_torch_import.py tests/test_mlx_router.py tests/test_mlx_metrics.py tests/test_mlx_model_adapters.py tests/test_mlx_observer.py tests/test_mlx_prune.py tests/test_mlx_save.py tests/test_mlx_data.py tests/test_mlx_cli.py tests/test_mlx_validation_metrics.py
```

Result: `99 passed, 2 skipped`.

## Pre-merge manual check

Before merging, run the small real LFM2.5 E2E validation:

```bash
MAX_SAMPLES=1 MAX_SEQ_LENGTH=64 OUTPUT_DIR=artifacts/mlx/lfm2-e2e-smoke \
  bash experiments/mlx-pruning.sh \
  LiquidAI/LFM2.5-8B-A1B-MLX-4bit \
  theblackcat102/evol-codealpaca-v1 \
  reap \
  0.25 \
  42
```

Then inspect `artifacts/mlx/lfm2-e2e-smoke/validation-metrics.json`.
