### PR TITLE
perf: hoist Qwen3 observer attention mask

### DIFF
--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -87,12 +87,25 @@ def _observe_qwen3_model(
     for sequence in calibration_sequences:
         tokens = _batch_tokens(mx, sequence)
         h = embed_tokens(tokens)
-
-        for layer_idx, layer in enumerate(layers):
-            mask = _attention_mask(
+        default_mask = (
+            _attention_mask(
                 h,
                 sequence_length=tokens.shape[-1],
-                mask_fn=mask_fn,
+                mask_fn=None,
+            )
+            if mask_fn is None
+            else None
+        )
+
+        for layer_idx, layer in enumerate(layers):
+            mask = (
+                default_mask
+                if mask_fn is None
+                else _attention_mask(
+                    h,
+                    sequence_length=tokens.shape[-1],
+                    mask_fn=mask_fn,
+                )
             )
             h = _run_attention(layer, h, mask)
             moe_input = _call_required(layer, "post_attention_layernorm", h)

--- a/tests/test_mlx_observer.py
+++ b/tests/test_mlx_observer.py
@@ -352,6 +352,35 @@ def test_observe_model_reports_only_moe_layers_in_partial_model():
 
 
 @requires_mlx
+def test_observe_model_reuses_default_qwen_mask_once_per_sequence(monkeypatch):
+    import mlx.core as mx
+
+    layers = [
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyMoeMlp(mx, top_k=1)),
+        TinyLayer(mx, TinyDenseMlp(mx)),
+    ]
+    model = TinyModel(mx, layers)
+    mask = object()
+    mask_calls = []
+
+    def make_mask(hidden_states, cache=None):
+        mask_calls.append((hidden_states.shape, cache))
+        return mask
+
+    monkeypatch.setattr("reap.observer.make_attention_mask", make_mask)
+
+    observe_model(
+        model,
+        [[0, 1]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+    )
+
+    assert mask_calls == [((1, 2, 2), None)]
+    assert [layer.self_attn.masks for layer in layers] == [[mask], [mask], [mask]]
+
+
+@requires_mlx
 def test_observe_model_calls_mask_fn_for_sequence_length_greater_than_one():
     import mlx.core as mx
 


### PR DESCRIPTION
## Summary
- Hoist Qwen3 default attention mask creation once per calibration sequence.
- Preserve per-layer custom mask_fn behavior.
- Add regression coverage for default mask reuse across Qwen3 layers.

## Tests
- uv run python -m pytest -q tests/test_mlx_observer.py
- uv run python -m pytest -q tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q tests/test_mlx_*.py

Closes #35