### PR TITLE
perf: make pairwise expert frequency opt-in

### DIFF
--- a/docs/observation-and-metrics.md
+++ b/docs/observation-and-metrics.md
@@ -150,11 +150,15 @@ Tracked fields:
 | --- | --- | --- |
 | `total_tokens` | scalar | Number of routed token positions, not multiplied by top-k. |
 | `expert_frequency` | `[num_experts]` | Count of selected router assignments per expert. |
-| `pairwise_expert_frequency` | `[num_experts, num_experts]` | Batch-level pairwise frequency summary. |
 | `ean_sum` | `[num_experts]` | Sum of selected expert output L2 norms. |
 | `weighted_ean_sum` | `[num_experts]` | Sum of output norms multiplied by router score. |
 | `weighted_expert_frequency_sum` | `[num_experts]` | Sum of selected router scores. |
 | `max_activations` | `[num_experts]` | Maximum selected expert output activation. |
+
+Optional debug tracking can be enabled with
+`PruningState.initialize(num_experts, track_pairwise=True)`. This allocates and
+reports `pairwise_expert_frequency` with shape `[num_experts, num_experts]`.
+Default observation leaves it disabled to avoid O(num_experts²) hot-path work.
 
 `accumulate` can accept a `RouterResult` or explicit `indices` and `scores`.
 Callers must also provide either selected expert outputs or precomputed selected
@@ -168,7 +172,6 @@ output norms and maxes.
 | --- | --- |
 | `total_tokens` | Routed token positions. |
 | `expert_frequency` | Selected-route counts. |
-| `pairwise_expert_frequency` | Batch pairwise frequency matrix. |
 | `expert_proba` | `expert_frequency / max(total_tokens, 1)`. |
 | `ean_sum` | Sum of selected output norms. |
 | `ean_mean` | `ean_sum / max(expert_frequency, eps)`. |
@@ -184,6 +187,5 @@ Never-selected experts report finite zeros for mean-style metrics.
 `expert_frequency.sum()` can exceed `total_tokens` when `top_k > 1`, because
 frequency counts selected routes and each token can select multiple experts.
 
-`pairwise_expert_frequency` is collected for telemetry and future analysis. It
-is not currently a supported pruning method.
-
+`pairwise_expert_frequency` is not currently a supported pruning method and is
+disabled by default.

--- a/src/reap/metrics.py
+++ b/src/reap/metrics.py
@@ -22,27 +22,34 @@ class PruningState:
     num_experts: int
     total_tokens: int
     expert_frequency: np.ndarray
-    pairwise_expert_frequency: np.ndarray
+    pairwise_expert_frequency: np.ndarray | None
     ean_sum: np.ndarray
     weighted_ean_sum: np.ndarray
     weighted_expert_frequency_sum: np.ndarray
     max_activations: np.ndarray
 
     @classmethod
-    def initialize(cls, num_experts: int) -> "PruningState":
+    def initialize(
+        cls,
+        num_experts: int,
+        *,
+        track_pairwise: bool = False,
+    ) -> "PruningState":
         """Create zero-initialized pruning state for ``num_experts`` experts."""
         num_experts = int(num_experts)
         if num_experts < 1:
             raise ValueError(f"num_experts must be positive, got {num_experts}.")
 
+        pairwise = (
+            np.zeros((num_experts, num_experts), dtype=np.int64)
+            if track_pairwise
+            else None
+        )
         return cls(
             num_experts=num_experts,
             total_tokens=0,
             expert_frequency=np.zeros(num_experts, dtype=np.int64),
-            pairwise_expert_frequency=np.zeros(
-                (num_experts, num_experts),
-                dtype=np.int64,
-            ),
+            pairwise_expert_frequency=pairwise,
             ean_sum=np.zeros(num_experts, dtype=np.float64),
             weighted_ean_sum=np.zeros(num_experts, dtype=np.float64),
             weighted_expert_frequency_sum=np.zeros(num_experts, dtype=np.float64),
@@ -115,9 +122,10 @@ class PruningState:
 
         self.total_tokens += token_count
         self.expert_frequency += batch_frequency
-        self.pairwise_expert_frequency += (
-            batch_frequency[:, None] + batch_frequency[None, :]
-        )
+        if self.pairwise_expert_frequency is not None:
+            self.pairwise_expert_frequency += (
+                batch_frequency[:, None] + batch_frequency[None, :]
+            )
 
         flat_norms = norms_array.reshape(-1).astype(np.float64, copy=False)
         flat_scores = scores_array.reshape(-1)
@@ -138,10 +146,9 @@ class PruningState:
             _FLOAT_EPS,
         )
 
-        return {
+        report = {
             "total_tokens": int(self.total_tokens),
             "expert_frequency": self.expert_frequency.copy(),
-            "pairwise_expert_frequency": self.pairwise_expert_frequency.copy(),
             "expert_proba": self.expert_frequency.astype(np.float64)
             / token_denominator,
             "ean_sum": self.ean_sum.copy(),
@@ -153,6 +160,11 @@ class PruningState:
             "reap": (self.weighted_ean_sum / count_denominator).astype(np.float32),
             "max_activations": self.max_activations.copy(),
         }
+        if self.pairwise_expert_frequency is not None:
+            report["pairwise_expert_frequency"] = (
+                self.pairwise_expert_frequency.copy()
+            )
+        return report
 
     def _validate_route_arrays(
         self,

--- a/tests/test_mlx_metrics.py
+++ b/tests/test_mlx_metrics.py
@@ -22,8 +22,7 @@ def test_pruning_state_initialize_shapes_and_dtypes():
     assert state.total_tokens == 0
     assert state.expert_frequency.shape == (3,)
     assert state.expert_frequency.dtype == np.int64
-    assert state.pairwise_expert_frequency.shape == (3, 3)
-    assert state.pairwise_expert_frequency.dtype == np.int64
+    assert state.pairwise_expert_frequency is None
     assert state.ean_sum.dtype == np.float64
     assert state.weighted_ean_sum.dtype == np.float64
     assert state.weighted_expert_frequency_sum.dtype == np.float64
@@ -32,10 +31,7 @@ def test_pruning_state_initialize_shapes_and_dtypes():
     report = state.report()
     assert report["total_tokens"] == 0
     np.testing.assert_array_equal(report["expert_frequency"], np.zeros(3))
-    np.testing.assert_array_equal(
-        report["pairwise_expert_frequency"],
-        np.zeros((3, 3)),
-    )
+    assert "pairwise_expert_frequency" not in report
     np.testing.assert_allclose(report["expert_proba"], np.zeros(3))
     np.testing.assert_allclose(report["ean_mean"], np.zeros(3))
     np.testing.assert_allclose(report["reap"], np.zeros(3))
@@ -119,10 +115,6 @@ def test_accumulate_from_selected_outputs_topk_one():
     report = state.report()
     assert report["total_tokens"] == 3
     np.testing.assert_array_equal(report["expert_frequency"], [2, 1])
-    np.testing.assert_array_equal(
-        report["pairwise_expert_frequency"],
-        [[4, 3], [3, 2]],
-    )
     np.testing.assert_allclose(report["expert_proba"], [2 / 3, 1 / 3])
     np.testing.assert_allclose(report["ean_sum"], [18.0, 6.0])
     np.testing.assert_allclose(report["ean_mean"], [9.0, 6.0])
@@ -153,10 +145,6 @@ def test_accumulate_from_precomputed_stats_topk_greater_than_one():
     report = state.report()
     assert report["total_tokens"] == 3
     np.testing.assert_array_equal(report["expert_frequency"], [2, 2, 2])
-    np.testing.assert_array_equal(
-        report["pairwise_expert_frequency"],
-        np.full((3, 3), 4),
-    )
     np.testing.assert_allclose(report["expert_proba"], [2 / 3, 2 / 3, 2 / 3])
     np.testing.assert_allclose(report["ean_sum"], [12.0, 14.0, 15.0])
     np.testing.assert_allclose(report["ean_mean"], [6.0, 7.0, 7.5])
@@ -169,8 +157,12 @@ def test_accumulate_from_precomputed_stats_topk_greater_than_one():
     np.testing.assert_allclose(report["max_activations"], [6.0, 10.0, 12.0])
 
 
-def test_accumulate_updates_sequential_batches_with_batch_pairwise_frequency():
-    state = PruningState.initialize(2)
+def test_accumulate_tracks_pairwise_frequency_when_enabled():
+    state = PruningState.initialize(2, track_pairwise=True)
+
+    assert state.pairwise_expert_frequency is not None
+    assert state.pairwise_expert_frequency.shape == (2, 2)
+    assert state.pairwise_expert_frequency.dtype == np.int64
 
     state.accumulate(
         indices=np.array([[0]], dtype=np.int64),
@@ -234,10 +226,7 @@ def test_empty_accumulation_is_noop_without_selected_outputs():
     report = state.report()
     assert report["total_tokens"] == 0
     np.testing.assert_array_equal(report["expert_frequency"], [0, 0])
-    np.testing.assert_array_equal(
-        report["pairwise_expert_frequency"],
-        [[0, 0], [0, 0]],
-    )
+    assert "pairwise_expert_frequency" not in report
     np.testing.assert_allclose(report["ean_sum"], [0.0, 0.0])
     np.testing.assert_allclose(report["weighted_ean_sum"], [0.0, 0.0])
     np.testing.assert_allclose(report["max_activations"], [0.0, 0.0])

--- a/tests/test_mlx_observer.py
+++ b/tests/test_mlx_observer.py
@@ -25,7 +25,6 @@ requires_mlx = pytest.mark.skipif(
 EXPECTED_PRUNING_KEYS = {
     "total_tokens",
     "expert_frequency",
-    "pairwise_expert_frequency",
     "expert_proba",
     "ean_sum",
     "ean_mean",
@@ -286,10 +285,6 @@ def test_observe_model_reports_pruning_keys_and_manual_values():
 
     assert report["total_tokens"] == 2
     np.testing.assert_array_equal(report["expert_frequency"], [1, 1, 0])
-    np.testing.assert_array_equal(
-        report["pairwise_expert_frequency"],
-        [[2, 2, 1], [2, 2, 1], [1, 1, 0]],
-    )
     np.testing.assert_allclose(report["expert_proba"], [0.5, 0.5, 0.0])
     np.testing.assert_allclose(report["ean_sum"], [norm0, norm1, 0.0])
     np.testing.assert_allclose(report["ean_mean"], [norm0, norm1, 0.0])


### PR DESCRIPTION
## Summary
- Make pairwise expert frequency tracking opt-in in PruningState.
- Skip default O(num_experts^2) pairwise allocation, accumulation, and report output.
- Preserve old pairwise behavior behind track_pairwise=True.
- Update observer/metrics tests and metrics documentation.

## Tests
- uv run python -m pytest -q tests/test_mlx_metrics.py tests/test_mlx_observer.py
- uv run python -m pytest -q tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q tests/test_mlx_*.py
- uv run python -m pytest -q
- uv lock --check

Closes #34