### PR TITLE
fix: skip multimodal calibration content blocks

### DIFF
--- a/src/reap/data.py
+++ b/src/reap/data.py
@@ -198,6 +198,8 @@ def _normalize_content(content: Any) -> str:
             if isinstance(item, Mapping):
                 if item.get("type") == "text" and isinstance(item.get("text"), str):
                     parts.append(item["text"])
+                elif item.get("type") not in (None, "text"):
+                    continue
                 else:
                     parts.append(json.dumps(dict(item), sort_keys=True))
             else:

--- a/tests/test_mlx_data.py
+++ b/tests/test_mlx_data.py
@@ -207,6 +207,76 @@ def test_conversation_records_fall_back_to_role_content_text():
     assert text == "human: Explain REAP.\nassistant: REAP prunes experts."
 
 
+def test_extract_text_skips_multimodal_content_blocks():
+    text = extract_text(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this."},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/image.png"},
+                        },
+                        {
+                            "type": "audio",
+                            "audio": {"url": "https://example.com/a.wav"},
+                        },
+                        {
+                            "type": "video",
+                            "video": {"url": "https://example.com/v.mp4"},
+                        },
+                        {"type": "text", "text": "Use one sentence."},
+                    ],
+                }
+            ]
+        },
+        tokenizer=WhitespaceTokenizer(),
+    )
+
+    assert text == "user: Describe this.\nUse one sentence."
+
+
+def test_load_calibration_sequences_tokenizes_only_text_content_blocks():
+    tokenizer = WhitespaceTokenizer()
+
+    sequences = load_calibration_sequences(
+        tokenizer,
+        "multimodal/data",
+        max_samples=1,
+        max_seq_length=10,
+        load_dataset_fn=lambda dataset_name, **kwargs: [
+            {
+                "text": [
+                    {"type": "text", "text": "Hello world"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                    {"type": "text", "text": "Goodbye"},
+                ]
+            }
+        ],
+    )
+
+    assert tokenizer.texts == ["Hello world\nGoodbye"]
+    np.testing.assert_array_equal(sequences[0]["input_ids"], [5, 5, 7])
+
+
+def test_extract_text_preserves_untyped_mapping_content_fallback():
+    text = extract_text(
+        {
+            "text": [
+                "metadata",
+                {"source": "manual", "value": 3},
+            ]
+        }
+    )
+
+    assert text == 'metadata\n{"source": "manual", "value": 3}'
+
+
 class RecordingShuffleDataset(list):
     def __init__(self, records):
         super().__init__(records)


### PR DESCRIPTION
## Summary
- Skip typed non-text content blocks during calibration text normalization.
- Preserve JSON fallback for untyped mapping content.
- Add regression coverage for multimodal message/text records.

## Tests
- uv run python -m pytest -q tests/test_mlx_data.py tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q tests/test_mlx_*.py
- uv run python -m pytest -q
- uv lock --check

Closes #40