### PR TITLE
fix: fall back from broken smoke chat templates

### DIFF
--- a/src/reap/save.py
+++ b/src/reap/save.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ from reap.model_adapters import infer_model_adapter
 
 
 _WEIGHT_PATTERNS = ("*.safetensors", "*.npz")
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -153,10 +155,15 @@ def generation_smoke(
         "apply_chat_template",
     ):
         messages = [{"role": "user", "content": prompt}]
-        prompt = tokenizer.apply_chat_template(
-            messages,
-            add_generation_prompt=True,
-        )
+        try:
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+            )
+        except Exception:
+            logger.warning(
+                "Chat template application failed, using raw prompt for smoke test",
+            )
 
     return generate_fn(
         model,

--- a/tests/test_mlx_save.py
+++ b/tests/test_mlx_save.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -509,3 +510,34 @@ def test_generation_smoke_formats_chat_prompt_and_calls_generate():
 
     assert result == "hello"
     assert calls == [(model, tokenizer, "<chat>Who are you?</chat>", 4)]
+
+
+def test_generation_smoke_falls_back_to_raw_prompt_when_chat_template_fails(caplog):
+    calls = []
+
+    class Tokenizer:
+        chat_template = "template"
+
+        def apply_chat_template(self, messages, *, add_generation_prompt):
+            del messages, add_generation_prompt
+            raise RuntimeError("broken template")
+
+    def generate_fn(model, tokenizer, *, prompt, max_tokens):
+        calls.append((model, tokenizer, prompt, max_tokens))
+        return "hello"
+
+    model = object()
+    tokenizer = Tokenizer()
+    caplog.set_level(logging.WARNING, logger="reap.save")
+
+    result = generation_smoke(
+        model,
+        tokenizer,
+        prompt="Who are you?",
+        max_tokens=4,
+        generate_fn=generate_fn,
+    )
+
+    assert result == "hello"
+    assert calls == [(model, tokenizer, "Who are you?", 4)]
+    assert "Chat template application failed" in caplog.text


### PR DESCRIPTION
## Summary
- Catch chat-template rendering failures in generation_smoke.
- Log a warning and continue smoke generation with the raw prompt.
- Add regression coverage for broken apply_chat_template fallback.

## Tests
- uv run python -m pytest -q tests/test_mlx_save.py tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q tests/test_mlx_*.py
- uv run python -m pytest -q
- uv lock --check

Closes #42