### PR TITLE
feat: configure smoke generation validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Core options:
 | `--metrics-file` | `validation-metrics.json` | Metrics filename or absolute path. |
 | `--verbose` | off | Print pipeline progress. |
 | `--no-smoke` | off | Skip generation smoke after save/reload validation. |
+| `--smoke-prompt` | `What is your name?` | Prompt for generation smoke validation. |
+| `--smoke-max-tokens` | `16` | Maximum tokens for generation smoke validation. |
 
 ## Metrics
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,8 @@ validation, optional smoke generation, and telemetry writing.
 | `--metrics-file` | `validation-metrics.json` | Metrics filename or absolute path. |
 | `--verbose` | off | Print phase progress messages. |
 | `--no-smoke` | off | Skip generation smoke after reload validation. |
+| `--smoke-prompt` | `What is your name?` | Prompt for generation smoke validation. |
+| `--smoke-max-tokens` | `16` | Maximum tokens for generation smoke validation. |
 
 ## Validation
 
@@ -44,6 +46,7 @@ The CLI rejects:
 - unsupported prune methods;
 - `max_samples < 1`;
 - `max_seq_length < 1`.
+- `smoke_max_tokens < 1`.
 
 Invalid arguments exit through `argparse` with code 2.
 
@@ -133,4 +136,3 @@ re-raises the exception. The failure payload includes:
 - exception message;
 - elapsed seconds before failure;
 - memory sample at failure.
-

--- a/docs/save-reload-validation.md
+++ b/docs/save-reload-validation.md
@@ -16,6 +16,8 @@ save_pruned_model(
     adapter=None,
     expected_expert_count=None,
     smoke_fn=None,
+    smoke_prompt="What is your name?",
+    smoke_max_tokens=16,
     load_fn=None,
     save_fn=None,
 ) -> SaveReloadResult
@@ -149,12 +151,15 @@ attribute exists.
 
 ## Smoke Generation
 
-`generation_smoke` runs a short generation with:
+`generation_smoke` runs a short generation with these default CLI settings:
 
 ```txt
 prompt: "What is your name?"
 max_tokens: 16
 ```
+
+Use `--smoke-prompt` and `--smoke-max-tokens` to override those values for a
+run. The configured prompt and token limit are recorded in smoke metrics.
 
 If the tokenizer has a chat template and `apply_chat_template`, the prompt is
 wrapped as a user message with `add_generation_prompt=True`.
@@ -177,4 +182,3 @@ smoke by passing `smoke_fn=None`.
 | Reload config expert mismatch | Mutated config was not saved or wrong artifact reloaded. |
 | First-dimension mismatch | Expert-stacked weights were not sliced consistently. |
 | LFM2 expert bias mismatch | `expert_bias` was not pruned or reloaded with stale shape. |
-

--- a/src/reap/entrypoint.py
+++ b/src/reap/entrypoint.py
@@ -52,6 +52,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip generation smoke after save/reload validation.",
     )
+    parser.add_argument(
+        "--smoke-prompt",
+        default="What is your name?",
+        help="Prompt for the generation smoke test.",
+    )
+    parser.add_argument(
+        "--smoke-max-tokens",
+        type=int,
+        default=16,
+        help="Maximum tokens for the generation smoke test.",
+    )
     return parser
 
 
@@ -87,9 +98,20 @@ def main(
     save_pruned_model_fn = (
         save_pruned_model if save_pruned_model_fn is None else save_pruned_model_fn
     )
-    smoke_fn = generation_smoke if smoke_fn is None and not args.no_smoke else smoke_fn
     if args.no_smoke:
         smoke_fn = None
+    elif smoke_fn is None:
+        smoke_prompt = args.smoke_prompt
+        smoke_max_tokens = args.smoke_max_tokens
+
+        def smoke_fn(model: Any, tokenizer: Any, config: Mapping[str, Any]) -> Any:
+            return generation_smoke(
+                model,
+                tokenizer,
+                config,
+                prompt=smoke_prompt,
+                max_tokens=smoke_max_tokens,
+            )
 
     metrics = RunMetrics(args.output_dir, args.metrics_file)
     metrics.record_runtime()
@@ -165,6 +187,8 @@ def main(
                 args.model_name,
                 adapter=adapter,
                 smoke_fn=smoke_fn,
+                smoke_prompt=args.smoke_prompt,
+                smoke_max_tokens=args.smoke_max_tokens,
             )
         metrics.record_save_reload(result, adapter=adapter)
         metrics.sample_memory("after_save_reload_smoke")
@@ -191,6 +215,7 @@ def _validate_args(args: argparse.Namespace) -> None:
     resolve_prune_method(args.prune_method)
     _validate_positive_int(args.max_samples, "max_samples")
     _validate_positive_int(args.max_seq_length, "max_seq_length")
+    _validate_positive_int(args.smoke_max_tokens, "smoke_max_tokens")
 
     ratio = float(args.compression_ratio)
     if not math.isfinite(ratio) or ratio < 0.0 or ratio >= 1.0:

--- a/src/reap/save.py
+++ b/src/reap/save.py
@@ -45,6 +45,8 @@ def save_pruned_model(
     adapter: Any | None = None,
     expected_expert_count: int | None = None,
     smoke_fn: Callable[[Any, Any, Mapping[str, Any]], Any] | None = None,
+    smoke_prompt: str = "What is your name?",
+    smoke_max_tokens: int = 16,
     load_fn: Callable[..., Any] | None = None,
     save_fn: Callable[..., Any] | None = None,
 ) -> SaveReloadResult:
@@ -95,8 +97,8 @@ def save_pruned_model(
     smoke_metrics = {
         "enabled": smoke_fn is not None,
         "completed": False,
-        "prompt": "What is your name?",
-        "max_tokens": 16,
+        "prompt": smoke_prompt,
+        "max_tokens": smoke_max_tokens,
         "elapsed_seconds": None,
         "generated_token_count": None,
         "result_preview": None,

--- a/tests/test_mlx_cli.py
+++ b/tests/test_mlx_cli.py
@@ -90,6 +90,8 @@ def test_help_works_without_heavy_runtime_imports():
     assert result.returncode == 0, result.stderr + result.stdout
     assert "--model-name" in result.stdout
     assert "--dataset-name" in result.stdout
+    assert "--smoke-prompt" in result.stdout
+    assert "--smoke-max-tokens" in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -101,6 +103,7 @@ def test_help_works_without_heavy_runtime_imports():
         (["--prune-method", "ean_ca"], "Unsupported prune method"),
         (["--max-samples", "0"], "max_samples"),
         (["--max-seq-length", "0"], "max_seq_length"),
+        (["--smoke-max-tokens", "0"], "smoke_max_tokens"),
     ],
 )
 def test_invalid_arguments_fail_before_pipeline_functions(extra_args, message):
@@ -221,6 +224,8 @@ def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_pa
     }
     assert events[3][4:] == ("frequency", 0.25)
     assert events[4][6]["smoke_fn"] is smoke
+    assert events[4][6]["smoke_prompt"] == "What is your name?"
+    assert events[4][6]["smoke_max_tokens"] == 16
     assert any("load:" in line for line in output)
     assert any("calibrate:" in line for line in output)
     assert any("observe:" in line for line in output)
@@ -236,6 +241,64 @@ def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_pa
     assert payload["run_config"]["actual_sample_count"] == 1
     assert payload["pruning"]["expert_count_before"] == 4
     assert payload["pruning"]["expert_count_after"] == 3
+
+
+def test_main_configures_default_generation_smoke_from_cli(tmp_path, monkeypatch):
+    save_kwargs = {}
+    generation_calls = []
+
+    def fake_generation_smoke(model, tokenizer, config, *, prompt, max_tokens):
+        generation_calls.append((model, tokenizer, config, prompt, max_tokens))
+        return "smoke-ok"
+
+    def fake_save_pruned_model(*args, **kwargs):
+        del args
+        save_kwargs.update(kwargs)
+        return SimpleNamespace(output_dir=tmp_path)
+
+    monkeypatch.setattr("reap.entrypoint.generation_smoke", fake_generation_smoke)
+
+    code = main(
+        [
+            "--model-name",
+            "model",
+            "--dataset-name",
+            "dataset",
+            "--output-dir",
+            str(tmp_path),
+            "--smoke-prompt",
+            "Summarize this domain.",
+            "--smoke-max-tokens",
+            "7",
+        ],
+        load_model_fn=lambda model_name: (object(), object(), {"num_experts": 1}),
+        load_calibration_sequences_fn=lambda *args, **kwargs: [{"input_ids": [1]}],
+        observe_model_fn=lambda *args, **kwargs: {0: {"reap": [1.0]}},
+        prune_experts_fn=lambda *args, **kwargs: {},
+        save_pruned_model_fn=fake_save_pruned_model,
+        print_fn=lambda message: None,
+    )
+
+    assert code == 0
+    assert save_kwargs["smoke_prompt"] == "Summarize this domain."
+    assert save_kwargs["smoke_max_tokens"] == 7
+
+    result = save_kwargs["smoke_fn"](
+        "reloaded-model",
+        "reloaded-tokenizer",
+        {"num_experts": 1},
+    )
+
+    assert result == "smoke-ok"
+    assert generation_calls == [
+        (
+            "reloaded-model",
+            "reloaded-tokenizer",
+            {"num_experts": 1},
+            "Summarize this domain.",
+            7,
+        )
+    ]
 
 
 def test_no_smoke_passes_no_smoke_function_to_save(tmp_path):
@@ -267,6 +330,8 @@ def test_no_smoke_passes_no_smoke_function_to_save(tmp_path):
 
     assert code == 0
     assert save_kwargs["smoke_fn"] is None
+    assert save_kwargs["smoke_prompt"] == "What is your name?"
+    assert save_kwargs["smoke_max_tokens"] == 16
 
 
 def test_keyboard_interrupt_returns_130_without_success_message():

--- a/tests/test_mlx_save.py
+++ b/tests/test_mlx_save.py
@@ -300,6 +300,29 @@ def test_smoke_function_runs_on_reloaded_model_not_original(tmp_path):
     assert smoke_calls == [(reloaded_model, reloaded_tokenizer, {"num_experts": 1})]
 
 
+def test_save_pruned_model_records_configured_smoke_prompt_and_max_tokens(tmp_path):
+    result = save_pruned_model(
+        object(),
+        object(),
+        {"num_experts": 1},
+        tmp_path / "saved",
+        "source-model",
+        smoke_fn=lambda model, tokenizer, config: "smoke-ok",
+        smoke_prompt="Summarize this domain.",
+        smoke_max_tokens=7,
+        save_fn=fake_save_factory([]),
+        load_fn=fake_load_factory(
+            make_reloaded_model(1),
+            object(),
+            {"num_experts": 1},
+        ),
+    )
+
+    assert result.metrics["smoke"]["prompt"] == "Summarize this domain."
+    assert result.metrics["smoke"]["max_tokens"] == 7
+    assert result.metrics["smoke"]["completed"] is True
+
+
 def test_save_pruned_model_uses_explicit_expected_count_when_config_missing(tmp_path):
     result = save_pruned_model(
         object(),


### PR DESCRIPTION
## Summary
- add --smoke-prompt and --smoke-max-tokens CLI flags
- pass configured smoke values into generation smoke and save/reload metrics
- document configurable smoke validation and cover CLI/save behavior with tests

## Tests
- uv run python -m pytest -q tests/test_mlx_cli.py tests/test_mlx_save.py tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q tests/test_mlx_*.py
- uv run python -m pytest -q
- uv lock --check

Closes #44