### PR TITLE
feat: tune observer eval frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Core options:
 | `--compression-ratio` | `0.25` | Fraction of experts to remove per MoE layer. |
 | `--max-samples` | `128` | Number of non-empty calibration samples. |
 | `--max-seq-length` | `2048` | Maximum token length per calibration sample. |
+| `--eval-frequency` | `1` | Evaluate the MLX graph every N observation layers. |
 | `--seed` | `42` | Dataset shuffle seed when shuffle is available. |
 | `--output-dir` | required | Directory for the pruned MLX-LM artifact. |
 | `--metrics-file` | `validation-metrics.json` | Metrics filename or absolute path. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ validation, optional smoke generation, and telemetry writing.
 | `--max-samples` | `128` | Maximum non-empty calibration samples. |
 | `--num-calibration-sequences` | alias | Alias for `--max-samples`. |
 | `--max-seq-length` | `2048` | Maximum tokens per calibration sequence. |
+| `--eval-frequency` | `1` | Evaluate the MLX graph every N observation layers. |
 | `--seed` | `42` | Shuffle seed when the dataset supports shuffle. |
 | `--metrics-file` | `validation-metrics.json` | Metrics filename or absolute path. |
 | `--verbose` | off | Print phase progress messages. |
@@ -45,7 +46,8 @@ The CLI rejects:
 - non-finite compression ratios such as `nan`;
 - unsupported prune methods;
 - `max_samples < 1`;
-- `max_seq_length < 1`.
+- `max_seq_length < 1`;
+- `eval_frequency < 1`;
 - `smoke_max_tokens < 1`.
 
 Invalid arguments exit through `argparse` with code 2.

--- a/docs/observation-and-metrics.md
+++ b/docs/observation-and-metrics.md
@@ -14,6 +14,7 @@ observe_model(
     *,
     adapter=None,
     debug_memory=False,
+    eval_frequency=1,
     eval_fn=None,
     mask_fn=None,
 ) -> dict[int, dict[str, Any]]
@@ -22,9 +23,13 @@ observe_model(
 Returns observer reports keyed by MoE layer index. Dense layers are replayed but
 do not receive reports.
 
-`eval_fn` defaults to `mx.eval`. It is called after every layer to force MLX
-evaluation boundaries and avoid unbounded lazy graph growth across layers and
-sequences.
+`eval_fn` defaults to `mx.eval`. By default, it is called after every layer to
+force MLX evaluation boundaries and avoid unbounded lazy graph growth across
+layers and sequences.
+
+`eval_frequency` controls that boundary. Values greater than 1 evaluate every N
+layers and also flush the final layer of each sequence when needed. Higher
+values reduce GPU synchronization barriers but increase peak memory.
 
 ## Qwen3 Replay
 
@@ -40,7 +45,7 @@ For each sequence:
    - run `post_attention_layernorm`;
    - run either MoE observation or dense MLP;
    - add the MLP residual;
-   - evaluate the hidden state.
+   - evaluate the hidden state when the configured eval boundary is reached.
 
 Qwen3 MoE layers route with `Qwen3MoeRouter`.
 
@@ -60,7 +65,7 @@ For each sequence:
    - run `ffn_norm`;
    - run either MoE observation or dense feed-forward;
    - add the feed-forward residual;
-   - evaluate the hidden state.
+   - evaluate the hidden state when the configured eval boundary is reached.
 
 LFM2 MoE layers route with `Lfm2MoeRouter`.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,6 +60,7 @@ Run config records user-facing CLI inputs:
 - `seed`
 - `max_samples`
 - `max_seq_length`
+- `eval_frequency`
 - `prune_method`
 - `resolved_prune_method`
 - `compression_ratio`
@@ -241,4 +242,3 @@ On failure, telemetry status is `failed` and `failure` contains:
 - `memory_at_failure`
 
 The original exception is re-raised after telemetry is written.
-

--- a/src/reap/entrypoint.py
+++ b/src/reap/entrypoint.py
@@ -39,6 +39,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=128,
     )
     parser.add_argument("--max-seq-length", type=int, default=2048)
+    parser.add_argument(
+        "--eval-frequency",
+        type=int,
+        default=1,
+        help=(
+            "Evaluate the MLX graph every N layers during observation. "
+            "Higher values reduce GPU syncs but increase peak memory."
+        ),
+    )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output-dir", required=True)
     parser.add_argument(
@@ -153,6 +162,7 @@ def main(
                 model,
                 calibration_sequences,
                 config,
+                eval_frequency=args.eval_frequency,
             )
         metrics.record_observer(observer_data, args.prune_method)
         metrics.sample_memory("after_observe")
@@ -215,6 +225,7 @@ def _validate_args(args: argparse.Namespace) -> None:
     resolve_prune_method(args.prune_method)
     _validate_positive_int(args.max_samples, "max_samples")
     _validate_positive_int(args.max_seq_length, "max_seq_length")
+    _validate_positive_int(args.eval_frequency, "eval_frequency")
     _validate_positive_int(args.smoke_max_tokens, "smoke_max_tokens")
 
     ratio = float(args.compression_ratio)

--- a/src/reap/observer.py
+++ b/src/reap/observer.py
@@ -31,6 +31,7 @@ def observe_model(
     *,
     adapter: Any | None = None,
     debug_memory: bool = False,
+    eval_frequency: int = 1,
     eval_fn: Callable[[Any], Any] | None = None,
     mask_fn: Callable[..., Any] | None = None,
 ) -> dict[int, dict[str, Any]]:
@@ -38,6 +39,7 @@ def observe_model(
     mx = _require_mlx_core()
     config = {} if config is None else config
     adapter = infer_model_adapter(model, config) if adapter is None else adapter
+    eval_frequency = _validate_eval_frequency(eval_frequency)
     eval_fn = mx.eval if eval_fn is None else eval_fn
 
     if getattr(adapter, "adapter_name", None) == "lfm2_moe":
@@ -47,6 +49,7 @@ def observe_model(
             config,
             adapter=adapter,
             debug_memory=debug_memory,
+            eval_frequency=eval_frequency,
             eval_fn=eval_fn,
             mask_fn=mask_fn,
         )
@@ -57,6 +60,7 @@ def observe_model(
         config,
         adapter=adapter,
         debug_memory=debug_memory,
+        eval_frequency=eval_frequency,
         eval_fn=eval_fn,
         mask_fn=mask_fn,
     )
@@ -69,6 +73,7 @@ def _observe_qwen3_model(
     *,
     adapter: Any,
     debug_memory: bool,
+    eval_frequency: int,
     eval_fn: Callable[[Any], Any],
     mask_fn: Callable[..., Any] | None,
 ) -> dict[int, dict[str, Any]]:
@@ -123,7 +128,8 @@ def _observe_qwen3_model(
                 dense_mlp = adapter.get_dense_mlp(layer)
                 h = h + dense_mlp(moe_input)
 
-            eval_fn(h)
+            if _should_eval_layer(layer_idx, len(layers), eval_frequency):
+                eval_fn(h)
             if debug_memory:
                 _log_memory(mx, layer_idx)
 
@@ -137,6 +143,7 @@ def _observe_lfm2_model(
     *,
     adapter: Any,
     debug_memory: bool,
+    eval_frequency: int,
     eval_fn: Callable[[Any], Any],
     mask_fn: Callable[..., Any] | None,
 ) -> dict[int, dict[str, Any]]:
@@ -179,7 +186,8 @@ def _observe_lfm2_model(
                 dense_mlp = adapter.get_dense_mlp(layer)
                 h = h_mid + dense_mlp(ffn_input)
 
-            eval_fn(h)
+            if _should_eval_layer(layer_idx, len(layers), eval_frequency):
+                eval_fn(h)
             if debug_memory:
                 _log_memory(mx, layer_idx)
 
@@ -195,6 +203,19 @@ def _require_mlx_core():
             "Install MLX in the active environment before observing."
         ) from exc
     return mx
+
+
+def _validate_eval_frequency(eval_frequency: int) -> int:
+    value = int(eval_frequency)
+    if value < 1:
+        raise ValueError(
+            f"eval_frequency must be a positive integer, got {eval_frequency}."
+        )
+    return value
+
+
+def _should_eval_layer(layer_idx: int, layer_count: int, eval_frequency: int) -> bool:
+    return (layer_idx + 1) % eval_frequency == 0 or layer_idx == layer_count - 1
 
 
 def _get_embed_tokens(model: Any) -> Callable[[Any], Any]:

--- a/src/reap/validation_metrics.py
+++ b/src/reap/validation_metrics.py
@@ -134,6 +134,7 @@ class RunMetrics:
                 "seed": getattr(args, "seed", None),
                 "max_samples": getattr(args, "max_samples", None),
                 "max_seq_length": getattr(args, "max_seq_length", None),
+                "eval_frequency": getattr(args, "eval_frequency", None),
                 "prune_method": getattr(args, "prune_method", None),
                 "resolved_prune_method": _resolve_method_or_none(
                     getattr(args, "prune_method", None)

--- a/tests/test_mlx_cli.py
+++ b/tests/test_mlx_cli.py
@@ -90,6 +90,7 @@ def test_help_works_without_heavy_runtime_imports():
     assert result.returncode == 0, result.stderr + result.stdout
     assert "--model-name" in result.stdout
     assert "--dataset-name" in result.stdout
+    assert "--eval-frequency" in result.stdout
     assert "--smoke-prompt" in result.stdout
     assert "--smoke-max-tokens" in result.stdout
 
@@ -103,6 +104,7 @@ def test_help_works_without_heavy_runtime_imports():
         (["--prune-method", "ean_ca"], "Unsupported prune method"),
         (["--max-samples", "0"], "max_samples"),
         (["--max-seq-length", "0"], "max_seq_length"),
+        (["--eval-frequency", "0"], "eval_frequency"),
         (["--smoke-max-tokens", "0"], "smoke_max_tokens"),
     ],
 )
@@ -142,8 +144,8 @@ def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_pa
         events.append(("calibrate", tokenizer_arg, dataset_name, kwargs))
         return [{"input_ids": [1, 2, 3]}]
 
-    def fake_observe_model(model_arg, sequences, config_arg):
-        events.append(("observe", model_arg, sequences, config_arg))
+    def fake_observe_model(model_arg, sequences, config_arg, **kwargs):
+        events.append(("observe", model_arg, sequences, config_arg, kwargs))
         return {0: {"reap": [1.0, 0.5, 0.25, 0.0]}}
 
     def fake_prune_experts(model_arg, config_arg, observer_data, method, ratio):
@@ -222,6 +224,7 @@ def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_pa
         "max_seq_length": 16,
         "seed": 9,
     }
+    assert events[2][4] == {"eval_frequency": 1}
     assert events[3][4:] == ("frequency", 0.25)
     assert events[4][6]["smoke_fn"] is smoke
     assert events[4][6]["smoke_prompt"] == "What is your name?"
@@ -238,9 +241,48 @@ def test_main_runs_pipeline_with_injected_functions_and_progress_messages(tmp_pa
     payload = json.loads(metrics_path.read_text(encoding="utf-8"))
     assert payload["status"] == "success"
     assert payload["run_config"]["model_name"] == "mlx-model"
+    assert payload["run_config"]["eval_frequency"] == 1
     assert payload["run_config"]["actual_sample_count"] == 1
     assert payload["pruning"]["expert_count_before"] == 4
     assert payload["pruning"]["expert_count_after"] == 3
+
+
+def test_main_passes_configured_eval_frequency_to_observer(tmp_path):
+    observe_kwargs = {}
+
+    def fake_observe_model(model_arg, sequences, config_arg, **kwargs):
+        del model_arg, sequences, config_arg
+        observe_kwargs.update(kwargs)
+        return {0: {"reap": [1.0]}}
+
+    code = main(
+        [
+            "--model-name",
+            "model",
+            "--dataset-name",
+            "dataset",
+            "--output-dir",
+            str(tmp_path),
+            "--eval-frequency",
+            "4",
+        ],
+        load_model_fn=lambda model_name: (object(), object(), {"num_experts": 1}),
+        load_calibration_sequences_fn=lambda *args, **kwargs: [{"input_ids": [1]}],
+        observe_model_fn=fake_observe_model,
+        prune_experts_fn=lambda *args, **kwargs: {},
+        save_pruned_model_fn=lambda *args, **kwargs: SimpleNamespace(
+            output_dir=tmp_path
+        ),
+        print_fn=lambda message: None,
+    )
+
+    assert code == 0
+    assert observe_kwargs == {"eval_frequency": 4}
+
+    payload = json.loads(
+        (tmp_path / "validation-metrics.json").read_text(encoding="utf-8")
+    )
+    assert payload["run_config"]["eval_frequency"] == 4
 
 
 def test_main_configures_default_generation_smoke_from_cli(tmp_path, monkeypatch):
@@ -362,8 +404,8 @@ def test_keyboard_interrupt_returns_130_without_success_message():
 def test_main_writes_failed_metrics_when_pipeline_phase_raises(tmp_path):
     output_dir = tmp_path / "failed-run"
 
-    def fail_observe(model, sequences, config):
-        del model, sequences, config
+    def fail_observe(model, sequences, config, **kwargs):
+        del model, sequences, config, kwargs
         raise RuntimeError("observer failed")
 
     with pytest.raises(RuntimeError, match="observer failed"):

--- a/tests/test_mlx_observer.py
+++ b/tests/test_mlx_observer.py
@@ -421,6 +421,70 @@ def test_observe_model_calls_eval_fn_after_each_layer():
 
 
 @requires_mlx
+def test_observe_model_eval_frequency_flushes_final_partial_group():
+    import mlx.core as mx
+
+    layers = [
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyMoeMlp(mx, top_k=1)),
+        TinyLayer(mx, TinyDenseMlp(mx)),
+    ]
+    model = TinyModel(mx, layers)
+    eval_calls = []
+
+    observe_model(
+        model,
+        [[0, 1]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+        eval_frequency=2,
+        mask_fn=lambda h, cache=None: None,
+        eval_fn=lambda h: eval_calls.append(h.shape),
+    )
+
+    assert eval_calls == [(1, 2, 2), (1, 2, 2)]
+
+
+@requires_mlx
+def test_observe_model_eval_frequency_does_not_duplicate_exact_final_group():
+    import mlx.core as mx
+
+    layers = [
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyMoeMlp(mx, top_k=1)),
+        TinyLayer(mx, TinyDenseMlp(mx)),
+        TinyLayer(mx, TinyDenseMlp(mx)),
+    ]
+    model = TinyModel(mx, layers)
+    eval_calls = []
+
+    observe_model(
+        model,
+        [[0, 1]],
+        {"num_experts": 3, "num_experts_per_tok": 1},
+        eval_frequency=2,
+        mask_fn=lambda h, cache=None: None,
+        eval_fn=lambda h: eval_calls.append(h.shape),
+    )
+
+    assert eval_calls == [(1, 2, 2), (1, 2, 2)]
+
+
+@requires_mlx
+def test_observe_model_rejects_invalid_eval_frequency():
+    import mlx.core as mx
+
+    model = TinyModel(mx, [TinyLayer(mx, TinyMoeMlp(mx, top_k=1))])
+
+    with pytest.raises(ValueError, match="eval_frequency"):
+        observe_model(
+            model,
+            [[0]],
+            {"num_experts": 3, "num_experts_per_tok": 1},
+            eval_frequency=0,
+        )
+
+
+@requires_mlx
 def test_observe_model_adds_shared_expert_to_hidden_flow_only():
     import mlx.core as mx
 
@@ -514,3 +578,48 @@ def test_observe_model_replays_lfm2_conv_attention_dense_and_moe_layers():
     assert eval_calls == [(1, 2, 2), (1, 2, 2)]
     assert len(dense_feed_forward.inputs) == 1
     assert np.isfinite(observer_data[1]["reap"]).all()
+
+
+@requires_mlx
+def test_observe_model_lfm2_eval_frequency_flushes_final_partial_group():
+    import mlx.core as mx
+
+    model = TinyModel(
+        mx,
+        [
+            TinyLfmLayer(
+                mx,
+                is_attention_layer=False,
+                feed_forward=TinyLfmDenseFeedForward(mx),
+            ),
+            TinyLfmLayer(
+                mx,
+                is_attention_layer=True,
+                feed_forward=TinyLfmMoeFeedForward(mx, top_k=1),
+            ),
+            TinyLfmLayer(
+                mx,
+                is_attention_layer=False,
+                feed_forward=TinyLfmDenseFeedForward(mx),
+            ),
+        ],
+    )
+    eval_calls = []
+
+    observer_data = observe_model(
+        model,
+        [[0, 1]],
+        {
+            "model_type": "lfm2_moe",
+            "num_experts": 3,
+            "num_experts_per_tok": 1,
+            "norm_topk_prob": False,
+            "use_expert_bias": False,
+        },
+        eval_frequency=2,
+        mask_fn=lambda h, cache=None, kind=None: kind,
+        eval_fn=lambda h: eval_calls.append(h.shape),
+    )
+
+    assert set(observer_data) == {1}
+    assert eval_calls == [(1, 2, 2), (1, 2, 2)]

--- a/tests/test_mlx_validation_metrics.py
+++ b/tests/test_mlx_validation_metrics.py
@@ -107,6 +107,7 @@ def test_run_metrics_writes_success_json_with_timings_and_throughput(tmp_path):
         seed=42,
         max_samples=2,
         max_seq_length=8,
+        eval_frequency=1,
         prune_method="reap",
         compression_ratio=0.25,
         output_dir=str(tmp_path),


### PR DESCRIPTION
## Summary
- add --eval-frequency CLI validation and observer wiring
- evaluate MLX graphs every N observation layers with final per-sequence flush
- record eval_frequency in run telemetry and update docs/tests

## Tests
- uv run python -m pytest -q tests/test_mlx_cli.py tests/test_mlx_observer.py tests/test_mlx_no_torch_import.py tests/test_mlx_validation_metrics.py
- uv run python -m pytest -q tests/test_mlx_*.py
- uv run python -m pytest -q
- uv lock --check
- git diff --check

Closes #43