### PR TITLE
refactor: align router normalization epsilon

### DIFF
--- a/docs/observation-and-metrics.md
+++ b/docs/observation-and-metrics.md
@@ -101,7 +101,8 @@ Qwen3 routing:
 4. Applies `mx.softmax(logits, axis=-1, precise=True)`.
 5. Selects top-k experts through `mx.argpartition`.
 6. Gathers selected softmax scores.
-7. Optionally renormalizes selected scores when `norm_topk_prob` is enabled.
+7. Optionally renormalizes selected scores with the shared epsilon denominator
+   when `norm_topk_prob` is enabled.
 8. Reshapes selected indices and scores back to leading dimensions.
 
 Live `top_k` on the module is preferred over config top-k.
@@ -117,7 +118,7 @@ LFM2 routing:
 5. Adds `expert_bias` before top-k selection when `use_expert_bias` is enabled.
 6. Selects top-k experts through `mx.argpartition`.
 7. Gathers selected scores.
-8. Optionally renormalizes selected scores with an epsilon denominator.
+8. Optionally renormalizes selected scores with the shared epsilon denominator.
 9. Casts scores back to the hidden-state dtype.
 
 When `use_expert_bias` is true, `moe.expert_bias` is required.

--- a/src/reap/router.py
+++ b/src/reap/router.py
@@ -10,6 +10,9 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 
+_NORM_EPSILON: float = 1e-20
+
+
 @dataclass(frozen=True)
 class RouterResult:
     """Architecture-neutral selected-router output."""
@@ -124,7 +127,9 @@ class Qwen3MoeRouter:
         flat_scores = mx.take_along_axis(gates, flat_indices, axis=-1)
 
         if self.norm_topk_prob:
-            flat_scores = flat_scores / flat_scores.sum(axis=-1, keepdims=True)
+            flat_scores = flat_scores / (
+                flat_scores.sum(axis=-1, keepdims=True) + _NORM_EPSILON
+            )
 
         output_shape = (*leading_shape, self.top_k)
         return RouterResult(
@@ -212,7 +217,9 @@ class Lfm2MoeRouter:
         indices = mx.argpartition(gates, kth=-self.top_k, axis=-1)[..., -self.top_k :]
         scores = mx.take_along_axis(gates, indices, axis=-1)
         if self.norm_topk_prob:
-            scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+            scores = scores / (
+                mx.sum(scores, axis=-1, keepdims=True) + _NORM_EPSILON
+            )
         scores = scores.astype(hidden_states.dtype)
 
         return RouterResult(

--- a/tests/test_mlx_router.py
+++ b/tests/test_mlx_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import importlib.util
 import os
 import subprocess
@@ -11,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from reap import router as router_module
 from reap.router import Lfm2MoeRouter, Qwen3MoeRouter, RouterResult
 
 
@@ -151,7 +153,9 @@ def qwen_reference(mx, mlp, hidden_states, top_k, norm_topk_prob):
     scores = mx.take_along_axis(gates, indices, axis=-1)
 
     if norm_topk_prob:
-        scores = scores / scores.sum(axis=-1, keepdims=True)
+        scores = scores / (
+            scores.sum(axis=-1, keepdims=True) + router_module._NORM_EPSILON
+        )
 
     output_shape = (*leading_shape, top_k)
     return indices.reshape(output_shape), scores.reshape(output_shape)
@@ -166,7 +170,9 @@ def lfm2_reference(mx, moe, hidden_states, top_k, norm_topk_prob):
     indices = mx.argpartition(gates, kth=-top_k, axis=-1)[..., -top_k:]
     scores = mx.take_along_axis(gates, indices, axis=-1)
     if norm_topk_prob:
-        scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+        scores = scores / (
+            mx.sum(scores, axis=-1, keepdims=True) + router_module._NORM_EPSILON
+        )
     return indices, scores.astype(hidden_states.dtype)
 
 
@@ -178,6 +184,15 @@ def assert_allclose(mx, actual, expected, *, atol=1e-6):
     diff = mx.max(mx.abs(actual - expected))
     mx.eval(diff)
     assert float(diff) <= atol
+
+
+def test_router_normalization_epsilon_is_shared():
+    assert router_module._NORM_EPSILON == 1e-20
+    assert "_NORM_EPSILON" in inspect.getsource(Qwen3MoeRouter.__call__)
+
+    lfm2_call_source = inspect.getsource(Lfm2MoeRouter.__call__)
+    assert "_NORM_EPSILON" in lfm2_call_source
+    assert "1e-20" not in lfm2_call_source
 
 
 @requires_mlx


### PR DESCRIPTION
## Summary
- add a shared router normalization epsilon constant
- use the shared epsilon in Qwen3 and LFM2 norm_topk_prob paths
- update router references/tests and observation docs

## Tests
- uv run python -m pytest -q tests/test_mlx_router.py tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q tests/test_mlx_*.py
- uv run python -m pytest -q
- uv lock --check
- git diff --check

Closes #50