### PR TITLE
docs: clarify pruning and router semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Adding a model family should usually mean adding or extending an adapter in
 coverage in `tests/test_mlx_model_adapters.py`, `tests/test_mlx_router.py`, and
 `tests/test_mlx_prune.py`.
 
+All currently supported MoE layers must prune to the same retained expert count.
+The first pruned MoE layer sets the expected count for the run; per-layer expert
+counts and per-layer compression ratios are not yet supported.
+
 ## Pruning Methods
 
 `--prune-method` selects the per-expert saliency score used to rank experts.
@@ -155,6 +159,10 @@ Higher scores are kept.
 | `ean_mean` | Mean selected expert output norm. |
 | `weighted_ean_sum` | Router-score-weighted sum of selected expert output norms. |
 | `max_activations` | Maximum selected expert output activation. |
+
+For LFM2 models with `use_expert_bias=True`, router-score-weighted methods use
+bias-adjusted selected scores. This matches the model's routed computation, but
+can rank experts differently from a pure-softmax REAP formulation.
 
 `--compression-ratio` must be in `[0, 1)`. For each MoE layer, REAP MLX prunes
 `int(num_experts * compression_ratio)` experts and always keeps at least one

--- a/docs/observation-and-metrics.md
+++ b/docs/observation-and-metrics.md
@@ -91,6 +91,9 @@ RouterResult(
 The leading dimensions match the input hidden states without the hidden
 dimension.
 
+`indices` and `scores` are in `argpartition` partition order. The top-k experts
+are present, but they are not guaranteed to be sorted by descending score.
+
 ## Qwen3 Router Semantics
 
 Qwen3 routing:
@@ -122,6 +125,11 @@ LFM2 routing:
 9. Casts scores back to the hidden-state dtype.
 
 When `use_expert_bias` is true, `moe.expert_bias` is required.
+
+The bias-adjusted selected scores flow into `PruningState.accumulate`, so
+`weighted_ean_sum` and `reap` include the LFM2 expert bias. This matches the
+actual routed model computation, but it can differ from the original REAP paper
+formulation that weights activations by pure softmax probabilities.
 
 ## Selected Expert Outputs
 

--- a/docs/pruning.md
+++ b/docs/pruning.md
@@ -20,6 +20,12 @@ prune_experts(
 
 Returns ascending retained expert indices for each pruned MoE layer.
 
+## Mutation Contract
+
+`prune_experts` mutates the live model and the passed `config` mapping in place.
+Callers that need original config values after pruning should copy the config
+before calling.
+
 ## Supported Methods
 
 | Method | Description |
@@ -135,9 +141,11 @@ After all MoE layers are pruned, config is updated with:
 - `config["num_experts_per_tok"] = min(top_k, retained_count)`
 - `config["top_k"]` only if that key already exists
 
-All pruned MoE layers must retain the same expert count. If different layers
-would retain different counts, pruning raises a `ValueError` because the current
-config format records one global `num_experts` value.
+All pruned MoE layers must retain the same expert count. The first pruned MoE
+layer sets the retained-count expectation, and subsequent pruned MoE layers must
+match it. If different layers would retain different counts, pruning raises a
+`ValueError` because the current config format records one global `num_experts`
+value.
 
 ## Validation Failures
 
@@ -154,5 +162,4 @@ Pruning raises before mutation or during mutation for:
 - LFM2 expert bias enabled but missing.
 
 Because pruning mutates in place, callers should treat failures during pruning
-as invalidating the live model object for save purposes.
-
+as invalidating the live model object and config mapping for save purposes.

--- a/src/reap/prune.py
+++ b/src/reap/prune.py
@@ -50,6 +50,9 @@ def prune_experts(
 ) -> dict[int, np.ndarray]:
     """Prune adapter-discovered MLX MoE experts in place.
 
+    This mutates both the live model and the passed config mapping in place.
+    Copy config before calling if pre-pruning values are still needed.
+
     Returns a mapping from layer index to ascending retained expert indices.
     """
     adapter = infer_model_adapter(model, config) if adapter is None else adapter

--- a/src/reap/router.py
+++ b/src/reap/router.py
@@ -15,7 +15,10 @@ _NORM_EPSILON: float = 1e-20
 
 @dataclass(frozen=True)
 class RouterResult:
-    """Architecture-neutral selected-router output."""
+    """Architecture-neutral selected-router output.
+
+    Indices and scores are in argpartition order, not sorted by score.
+    """
 
     indices: Any
     scores: Any


### PR DESCRIPTION
## Summary
- document prune_experts config mutation and uniform retained expert count constraints
- document RouterResult argpartition ordering semantics
- document LFM2 expert-bias impact on REAP weighted metrics

## Tests
- uv run python -m pytest -q tests/test_mlx_router.py tests/test_mlx_prune.py tests/test_mlx_no_torch_import.py
- uv run python -m pytest -q
- uv lock --check
- git diff --check

Closes #45
Closes #46
Closes #47
Closes #48